### PR TITLE
Openapi.yaml + Openapi.yaml voor referentie-implementatie toegevoegd. 

### DIFF
--- a/api-specificatie/openapi.yaml
+++ b/api-specificatie/openapi.yaml
@@ -1,14 +1,15 @@
 openapi: 3.0.0
 servers:
-# Added by API Auto Mocking Plugin
-  - description: SwaggerHub API Auto Mocking
-    url: https://virtserver.swaggerhub.com/King4/test/1.0.0
-  - description: SwaggerHub API Auto Mocking
+  - description: "SwaggerHub API Auto Mocking"
     url: https://virtserver.swaggerhub.com/VNGRealisatie/api/open_raadsinformatie/v1
+  - description: "Referentie-implementatie"
+    url: https://www.voorbeeldgemeente.nl/api/open_raadsinformatie/v1
 info:
-  title: Open Raads- en StatenInformatie
-  description: "Dit is de concept-versie van de API-documentatie voor Open RaadsInformatie. Deze versie is gebaseerd op de 2e versie en op de verbetervoorstellen die op het [discussie-platform](discussie.kinggemeenten.nl/discussie/gemma/koppelvlak-open-raadsinformatie/eeste-iteratie-voor-de-api-documentatie-beschikbaar) zijn geplaatst. Daarnaast is in deze versie een toevoeging gedaan [(zie documentatie)](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) waardoor de API ook JSON-LD compliant is.Vooralsnog wordt er geen centraal context-bestand gepubliceerd, maar de standaard is wel voorbereid op het gebruik van een context bestand."
-  version: "1.0.0"
+  title: Open Raadsinformatie
+  description: "<body>Dit is de concept-versie van de API-documentatie voor Open RaadsInformatie. Deze versie is gebaseerd op de 2e versie en op de verbetervoorstellen die op het discussie-platform `discussie.kinggemeenten.nl/discussie/gemma/koppelvlak-open-raadsinformatie/eeste-iteratie-voor-de-api-documentatie-beschikbaar` zijn geplaatst. Daarnaast is in deze versie een toevoeging gedaan waardoor de API ook JSON-LD compliant is.Vooralsnog wordt er geen centraal context-bestand gepubliceerd, maar de standaard is wel voorbereid op het gebruik van een context bestand.</body>"
+  version: "1.0"
+  x-imvertor-generator-version: "1.58.0"
+  x-yamlCompiler-stylesheets-version: "20200121"
   contact:
     url: https://github.com/VNG-Realisatie/Open-Raadsinformatie
   license:
@@ -17,8 +18,8 @@ info:
 paths:
   /aanwezigedeelnemers:
     get:
-      operationId: getAanwezigeDeelnemers
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een collectie AANWEZIGEDEELNEMERS retourneert."
+      operationId: getcollectionaanwezigedeelnemers
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een collectie agendapunten retourneert.</p></body>"
       parameters: 
         - in: query
           name: page
@@ -27,12 +28,13 @@ paths:
           schema:
             type: integer
             minimum: 1
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
         - in: query
           name: rolnaam
-          description: "De rol waarin de PERSOON is bij de vergadering"
+          description: "De rol waarin de persoon aanwezig is bij de vergadering"
           required: false
           schema:
-              $ref: "#/components/schemas/RolNaam"
+            $ref: "#/components/schemas/RolNaam"
         - in: query
           name: vertegenwoordigdorganisatie
           description: "De naam van de organisatie die iemand vertegenwoordigt."
@@ -45,328 +47,247 @@ paths:
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Pagination-Page:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
             X-Pagination-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                type: object
-                properties:
-                  _links:
-                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
-                  _embedded:
-                    type: object
-                    properties:
-                      aanwezigedeelnemers:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/AanwezigeDeelnemer'
+                $ref: '#/components/schemas/AanwezigeDeelnemerHalCollectie'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
-      - Aanwezigedeelnemers
+      - Aanwezige deelnemers
+  /aanwezigedeelnemers/{aanwezigedeelnemeridentificatie}:
+    delete:
+      operationId: delaanwezigedeelnemer
+      description: "<body><p>Het bericht dat de JSON/REST API voor het verwijderen van gegevens van een agendapunt .</p></body>"
+      parameters: 
+        - in: path
+          name: aanwezigedeelnemeridentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+      responses:
+        '200':
+          description: "Verwijderactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+        '204':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/204"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+      tags: 
+      - Aanwezige deelnemers
+    get:
+      operationId: getresourceaanwezigedeelnemersAanwezigedeelnemeridentificatie
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van vergaderingsgegevens retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: aanwezigedeelnemeridentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/AanwezigeDeelnemerHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Aanwezige deelnemers
     post:
-      operationId: postAanwezigeDeelnemer
-      description: "Registreer een AANWEZIGEDEELNEMER."
+      operationId: postaanwezigedeelnemersAanwezigedeelnemeridentificatie
+      description: "<body><p>Het bericht dat de JSON/REST API voor het vastleggen van aanwezige deelnemers retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: aanwezigedeelnemeridentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/AanwezigeDeelnemerHal'
       responses:
         '201':
-          description: ''
+          description: "OK"
           headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-          content:
-            application/json:
+            Location:
+              description: "URI van de nieuwe resource"
               schema:
-                $ref: '#/components/schemas/AanwezigeDeelnemer'
+                type: string
+                format: uri
+                example: '/aanwezigedeelnemers/{aanwezigedeelnemeridentificatie}/'
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/AanwezigeDeelnemerHal'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Aanwezigedeelnemers
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AanwezigeDeelnemer'
-        required: true
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Aanwezige deelnemers
     put:
-      operationId: putAanwezigeDeelnemer
-      description: "Wijzig een bestaande AANWEZIGEDEELNEMER"
+      operationId: putaanwezigedeelnemersAanwezigedeelnemeridentificatie
+      description: "<body><p>Het bericht dat de JSON/REST API voor het wijzigen van aanwezige deelnemers retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: aanwezigedeelnemeridentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/AanwezigeDeelnemerHal'
       responses:
         '200':
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/AanwezigeDeelnemer'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Aanwezigedeelnemers
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AanwezigeDeelnemer'
-        required: true
-    parameters: []
-  /aanwezigedeelnemers/{aanwezigedeelnemeridentificatie}:
-    get:
-      operationId: getAanwezigeDeelnemer
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een AANWEZIGEDEELNEMER retourneert."
-      parameters: 
-        - in: path
-          name: aanwezigedeelnemeridentificatie
-          description: ""
-          required: true
-          schema:
-            type: string
-            maxLength: 10
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/AanwezigeDeelnemer'
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
-      - Aanwezigedeelnemers
-    delete:
-      operationId: delAanwezigeDeelnemer
-      description: "Het bericht dat de JSON/REST API voor het verwijderen van AANZEZIGEDEELNEMER. Als een AANWEZIGEDEELNEMER wordt verwijderd is het de rol van de provider om de gerelateerde STEMMEN en SPREEKFRAGMENTEN te verwijderen."
-      parameters: 
-        - in: path
-          name: aanwezigedeelnemeridentificatie
-          description: ""
-          required: true
-          schema:
-            type: string
-            maxLength: 10
-      responses:
-        "204":
-          description: ""
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-        - Aanwezigedeelnemers
-  /agendapunten/{agendapuntnummer}:
-    get:
-      operationId: getAgendapunt
-      description: "Het bericht dat de JSON/REST API voor het ophalen van gegevens van een agendapunt retourneert."
-      parameters: 
-        - in: path
-          name: agendapuntnummer
-          description: "Het nummer van het agendapunt op de agenda."
-          required: true
-          schema:
-            type: string
-            maxLength: 10
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/Agendapunt'
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-      - Agendapunten
-    delete:
-      operationId: delAgendapunt
-      description: "Het bericht dat de JSON/REST API voor het verwijderen van aganedapunt."
-      parameters: 
-        - in: path
-          name: agendapuntnummer
-          description: "Het nummer van het agendapunt op de agenda."
-          required: true
-          schema:
-            type: string
-            maxLength: 10
-      responses:
-        "204":
-          description: ""
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-        - Agendapunten
+      - Aanwezige deelnemers
   /agendapunten:
     get:
-      operationId: getAgendapunten
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een collectie agendapunten retourneert."
+      operationId: Getagendapunten
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een collectie agendapunten retourneert.</p></body>"
       parameters: 
         - in: query
           name: page
@@ -381,248 +302,253 @@ paths:
           required: false
           schema:
             type: string
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
       responses:
         '200':
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Pagination-Page:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
             X-Pagination-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                type: object
-                properties:
-                  _links:
-                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
-                  _embedded:
-                    type: object
-                    properties:
-                      agendapunten:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Agendapunt'
+                $ref: '#/components/schemas/AgendapuntHalCollectie'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Agendapunten
+  /agendapunten/{agendapuntnummer}:
+    delete:
+      operationId: delagendapunt
+      description: "<body><p>Het bericht dat de JSON/REST API voor het verwijderen van gegevens van een agendapunt .</p></body>"
+      parameters: 
+        - in: path
+          name: agendapuntnummer
+          description: "Het nummer van het agendapunt op de agenda."
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+      responses:
+        '200':
+          description: "Verwijderactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+        '204':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/204"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+      tags: 
+      - Agendapunten
+    get:
+      operationId: getagendapunt
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen gegevens van een agendapunt retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: agendapuntnummer
+          description: "Het nummer van het agendapunt op de agenda."
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/AgendapuntHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
       - Agendapunten
     post:
-      operationId: postAgendapunt
-      description: "Registreer een agendapunt."
+      operationId: postagendapuntenAgendapuntnummer
+      description: "<body><p>Het vastleggen van een AGENDAPUNT</p></body>"
+      parameters: 
+        - in: path
+          name: agendapuntnummer
+          description: "Het nummer van het agendapunt op de agenda."
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/AgendapuntHal'
       responses:
         '201':
-          description: ''
-          headers: 
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/json:
+          description: "OK"
+          headers:
+            Location:
+              description: "URI van de nieuwe resource"
               schema:
-                $ref: '#/components/schemas/Agendapunt'
+                type: string
+                format: uri
+                example: '/agendapunten/{agendapuntnummer}/'
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/AgendapuntHal'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
-      tags:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
       - Agendapunten
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Agendapunt'
-        required: true
     put:
-      operationId: putAgendapunt
-      description: "Wijzig een bestaand Agendapunt"
+      operationId: putagendapuntenAgendapuntnummer
+      description: "<body><p>Het wijzigen van een AGENDAPUNT</p></body>"
+      parameters: 
+        - in: path
+          name: agendapuntnummer
+          description: "Het nummer van het agendapunt op de agenda."
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/AgendapuntHal'
       responses:
         '200':
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/Agendapunt'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
-      tags:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
       - Agendapunten
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Agendapunt'
-        required: true
-    parameters: []
-  /amendementen/{informatieobjectidentificatie}:
-    get:
-      operationId: getAmendement
-      description: "Het bericht dat de JSON/REST API voor het ophalen van gegevens van een amendement retourneert."
-      parameters: 
-        - in: path
-          name: informatieobjectidentificatie
-          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
-          required: true
-          schema:
-            type: string
-            maxLength: 40
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/Amendement'
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-      - Amendementen
-    delete:
-      operationId: delamendement
-      description: "Het bericht dat de JSON/REST API voor het verwijderen van amendement."
-      parameters: 
-        - in: path
-          name: informatieobjectidentificatie
-          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
-          required: true
-          schema:
-            type: string
-            maxLength: 40
-      responses:
-        "204":
-          description: ""
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/problem+json:
-              schema:
-                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-        - Amendementen
   /amendementen:
     get:
-      operationId: getAmendementen
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een collectie amendementen retourneert."
+      operationId: Getamendementen
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een collectie amendementen retourneert.</p></body>"
       parameters: 
         - in: query
           name: page
@@ -633,32 +559,26 @@ paths:
             minimum: 1
         - in: query
           name: auteur
-          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creëren van de inhoud van het INFORMATIEOBJECT. Het kan zowel een medewerker of organisatorische eenheid van de zaakbehandelende organisatie betreffen als een externe partij (persoon of organisatie). Het betreft het Dublin Core metadata-element ‘Creator’ met als toelichting: Examples of Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity. Van een ontvangen informatieobject kan de afzender de auteur zijn maar dat kan ook een ander zijn bijvoorbeeld in het geval dat de afzender een document van een derde meestuurt. Indien het informatieobject in een geautomatiseerd proces is vervaardigd, dan wordt als auteur vermeld degene die dat informatieobject ondertekend zou hebben dan wel, bij informatieobjecten waarbij van ondertekening geen sprake is (zoals bijvoorbeeld bij het omzetten van de zaakgegevens naar een duurzaam bewaarbaar informatieobject in pdf), degene die verantwoordelijk is voor de inhoud van het informatieobject vanuit zijn of haar rol bij de zaak (veelal degene in de rol van Zaakcoördinator). De naamgegevens van de auteur zijnde een betrokkene die in een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur niet in een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk persoon of organisatie zijnde de auteur. In het laatste geval verdient het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap wordt uitgeoefend."
+          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creÃ«ren van de inhoud van het INFORMATIEOBJECT. Het kan zowel een medewerker of organisatorische eenheid van de zaakbehandelende organisatie betreffen als een externe partij (persoon of organisatie). Het betreft het Dublin Core metadata-element â€˜Creatorâ€™ met als toelichting: Examples of Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity. Van een ontvangen informatieobject kan de afzender de auteur zijn maar dat kan ook een ander zijn bijvoorbeeld in het geval dat de afzender een document van een derde meestuurt. Indien het informatieobject in een geautomatiseerd proces is vervaardigd, dan wordt als auteur vermeld degene die dat informatieobject ondertekend zou hebben dan wel, bij informatieobjecten waarbij van ondertekening geen sprake is (zoals bijvoorbeeld bij het omzetten van de zaakgegevens naar een duurzaam bewaarbaar informatieobject in pdf), degene die verantwoordelijk is voor de inhoud van het informatieobject vanuit zijn of haar rol bij de zaak (veelal degene in de rol van ZaakcoÃ¶rdinator). De naamgegevens van de auteur zijnde een betrokkene die in een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur niet in een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk persoon of organisatie zijnde de auteur. In het laatste geval verdient het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap wordt uitgeoefend."
           required: false
           schema:
             type: string
             maxLength: 200
         - in: query
           name: bronorganisatie
-          description: "bronorganisatie bronorganisatie Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Het betreft het RSIN (Rechtspersonen en Samenwerkingsverbanden InformatieNummer) zoals dat door de KvK in het NHR aan elk rechtspersoon en samenwerkingsverband is toegekend. Dit identificeert uniek de organisatie, zijnde een rechtspersoon of samenwerkingsverband, dat het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Met het laatste doelen we er op dat bij uitwisseling van een informatieobject tussen samenwerkende organisaties de unieke aanduiding van het informatieobject niet wijzigt mits de ontvangende organisatie geen wijzigingen in het informatieobject aanbrengt. In het laatste geval ontstaat een nieuw informatieobject. Het RSIN staat in het Handelsregister (NHR) en op het daaraan te ontlenen uittreksel. Deze attribuutsoort vormt tezamen met de Informatieobjectidentificatie de unieke aanduiding van een informatieobject voor geheel Nederland. De waarde van dit attribuutsoort wijzigt niet, ook niet indien (de behandeling van) het informatieobject over zou gaan naar een andere organisatie. Er is immers maar één organisatie die het informatieobject gecreëerd of als eerste vastgelegd heeft. De in het NHR voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden."
+          description: "bronorganisatie bronorganisatie Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Het betreft het RSIN (Rechtspersonen en Samenwerkingsverbanden InformatieNummer) zoals dat door de KvK in het NHR aan elk rechtspersoon en samenwerkingsverband is toegekend. Dit identificeert uniek de organisatie, zijnde een rechtspersoon of samenwerkingsverband, dat het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Met het laatste doelen we er op dat bij uitwisseling van een informatieobject tussen samenwerkende organisaties de unieke aanduiding van het informatieobject niet wijzigt mits de ontvangende organisatie geen wijzigingen in het informatieobject aanbrengt. In het laatste geval ontstaat een nieuw informatieobject. Het RSIN staat in het Handelsregister (NHR) en op het daaraan te ontlenen uittreksel. Deze attribuutsoort vormt tezamen met de Informatieobjectidentificatie de unieke aanduiding van een informatieobject voor geheel Nederland. De waarde van dit attribuutsoort wijzigt niet, ook niet indien (de behandeling van) het informatieobject over zou gaan naar een andere organisatie. Er is immers maar Ã©Ã©n organisatie die het informatieobject gecreÃ«erd of als eerste vastgelegd heeft. De in het NHR voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden."
           required: false
           schema:
             type: integer
             maximum: 9.99999999E8
         - in: query
           name: creatiedatum
-          description: "creatiedatum creatiedatum Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Deze datum verwijst gewoonlijk naar de creatie van het INFORMATIEOBJECT. Het betreft het Dublin Core metadata-element ‘Date’ met als toelichting: Typically, Date will be associated with the creation or availability of the resource. Recommended best practice for encoding the date value is defined in a profile of ISO 8601 (W3CDTF) and includes (among others) dates of the form YYYY-MM-DD. Alle geldige datums gelegen op of voor de huidige datum en tijd"
+          description: "creatiedatum creatiedatum Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Deze datum verwijst gewoonlijk naar de creatie van het INFORMATIEOBJECT. Het betreft het Dublin Core metadata-element â€˜Dateâ€™ met als toelichting: Typically, Date will be associated with the creation or availability of the resource. Recommended best practice for encoding the date value is defined in a profile of ISO 8601 (W3CDTF) and includes (among others) dates of the form YYYY-MM-DD. Alle geldige datums gelegen op of voor de huidige datum en tijd"
           required: false
           schema:
             type: string
             format: date
-        - in: query
-          name: datumingediend
-          description: "De datum waarop het BESLUITVORMINGSSTUK is ingediend"
-          required: false
-          schema:
-            type: string
-            format: date
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
         - in: query
           name: omschrijving
           description: "De omschrijving van het BESLUITVORMINGSSTUK Dit kan de omschrijving zijn van de MOTIE, het AMENDEMENT of het VOORSTEL"
@@ -666,26 +586,12 @@ paths:
           schema:
             type: string
         - in: query
-          name: ontvangstdatum
-          description: "ontvangstdatum ontvangstdatum De datum waarop het INFORMATIEOBJECT ontvangen is. De datum waarop het INFORMATIEOBJECT ontvangen is. Het gaat hier om de datum waarop het INFORMATIEOBJECT ontvangen is door de zaakbehandelende organisatie(s), dus niet door een specifieke afdeling of medewerker daarvan. Alle geldige datums gelegen op, voor of na de huidige datum en tijd"
-          required: false
-          schema:
-            type: string
-            format: date
-        - in: query
           name: taal
-          description: "Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT Het betreft het Dublin Core metadata-element ‘Language’ met als toelichting: Recommended best practice is to use RFC 3066 (RFC3066), which, in conjunction with ISO 639 (ISO639), defines two- and three-letter primary language tags with optional subtags. Examples include “en” or “eng” for English, “akk  for Akkadian, and “en-GB” for English used in the United Kingdom. De Nederlandse taal wordt gecodeerd als “dut”. bij voorkeur ISO 639-2/B"
+          description: "Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT Het betreft het Dublin Core metadata-element â€˜Languageâ€™ met als toelichting: Recommended best practice is to use RFC 3066 (RFC3066), which, in conjunction with ISO 639 (ISO639), defines two- and three-letter primary language tags with optional subtags. Examples include â€œenâ€? or â€œengâ€? for English, â€œakk  for Akkadian, and â€œen-GBâ€? for English used in the United Kingdom. De Nederlandse taal wordt gecodeerd als â€œdutâ€?. bij voorkeur ISO 639-2/B"
           required: false
           schema:
             type: string
             maxLength: 20
-        - in: query
-          name: titel
-          description: "titel titel De naam waaronder het INFORMATIEOBJECT formeel bekend is. De naam waaronder het INFORMATIEOBJECT formeel bekend is. Het betreft het Dublin Core metadata-element ‘Title’ met als toelichting: Typically, Title will be a name by which the resource is formally known. alle alfanumerieke tekens"
-          required: false
-          schema:
-            type: string
-            maxLength: 200
         - in: query
           name: toelichting
           description: "De toelichting op het AMENDEMENT"
@@ -694,7 +600,7 @@ paths:
             type: string
         - in: query
           name: versie
-          description: "versie versie Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Het gaat hier om een versienummer zoals ‘0.2’ en 1.0’. Ofschoon we er voor gekozen hebben om zowel dit attribuuttype als het attribuuttype Status optioneel te verklaren, ware het aan te bevelen bij elk documemt in ieder geval één van beide attributen van een waarde te voorzien. Nb: De attribuutsoort is in versie 2.0 verplaatst van ENKELVOUDIG INFORMATIEOBJECT naar INFORMATIEOBJECT. Alle alfanumerieke tekens m.u.v. diacrieten"
+          description: "versie versie Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Het gaat hier om een versienummer zoals â€˜0.2â€™ en 1.0â€™. Ofschoon we er voor gekozen hebben om zowel dit attribuuttype als het attribuuttype Status optioneel te verklaren, ware het aan te bevelen bij elk documemt in ieder geval Ã©Ã©n van beide attributen van een waarde te voorzien. Nb: De attribuutsoort is in versie 2.0 verplaatst van ENKELVOUDIG INFORMATIEOBJECT naar INFORMATIEOBJECT. Alle alfanumerieke tekens m.u.v. diacrieten"
           required: false
           schema:
             type: string
@@ -704,444 +610,247 @@ paths:
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/Amendement'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-      - Amendementen
-    post:
-      operationId: postAmendement
-      description: "Registreer een amendement."
-      responses:
-        '201':
-          description: ''
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Amendement'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Amendementen
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Amendement'
-        required: true
-    put:
-      operationId: putAmendement
-      description: "Wijzig een bestaand Amendement"
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/Amendement'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Amendementen
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Amendement'
-        required: true
-  /besluitvormingsstukken:
-    get:
-      operationId: getBesluitvormingsstukken
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een collectie besluitvormingsstukken retourneert."
-      parameters: 
-        - in: query
-          name: page
-          description: "Een pagina binnen de gepagineerde resultatenset."
-          required: false
-          schema:
-            type: integer
-            minimum: 1
-        - in: query
-          name: auteur
-          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creëren van de inhoud van het INFORMATIEOBJECT. Het kan zowel een medewerker of organisatorische eenheid van de zaakbehandelende organisatie betreffen als een externe partij (persoon of organisatie). Het betreft het Dublin Core metadata-element ‘Creator’ met als toelichting: Examples of Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity. Van een ontvangen informatieobject kan de afzender de auteur zijn maar dat kan ook een ander zijn bijvoorbeeld in het geval dat de afzender een document van een derde meestuurt. Indien het informatieobject in een geautomatiseerd proces is vervaardigd, dan wordt als auteur vermeld degene die dat informatieobject ondertekend zou hebben dan wel, bij informatieobjecten waarbij van ondertekening geen sprake is (zoals bijvoorbeeld bij het omzetten van de zaakgegevens naar een duurzaam bewaarbaar informatieobject in pdf), degene die verantwoordelijk is voor de inhoud van het informatieobject vanuit zijn of haar rol bij de zaak (veelal degene in de rol van Zaakcoördinator). De naamgegevens van de auteur zijnde een betrokkene die in een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur niet in een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk persoon of organisatie zijnde de auteur. In het laatste geval verdient het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap wordt uitgeoefend."
-          required: false
-          schema:
-            type: string
-            maxLength: 200
-        - in: query
-          name: bronorganisatie
-          description: "bronorganisatie bronorganisatie Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Het betreft het RSIN (Rechtspersonen en Samenwerkingsverbanden InformatieNummer) zoals dat door de KvK in het NHR aan elk rechtspersoon en samenwerkingsverband is toegekend. Dit identificeert uniek de organisatie, zijnde een rechtspersoon of samenwerkingsverband, dat het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Met het laatste doelen we er op dat bij uitwisseling van een informatieobject tussen samenwerkende organisaties de unieke aanduiding van het informatieobject niet wijzigt mits de ontvangende organisatie geen wijzigingen in het informatieobject aanbrengt. In het laatste geval ontstaat een nieuw informatieobject. Het RSIN staat in het Handelsregister (NHR) en op het daaraan te ontlenen uittreksel. Deze attribuutsoort vormt tezamen met de Informatieobjectidentificatie de unieke aanduiding van een informatieobject voor geheel Nederland. De waarde van dit attribuutsoort wijzigt niet, ook niet indien (de behandeling van) het informatieobject over zou gaan naar een andere organisatie. Er is immers maar één organisatie die het informatieobject gecreëerd of als eerste vastgelegd heeft. De in het NHR voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden."
-          required: false
-          schema:
-            type: integer
-            maximum: 9.99999999E8
-        - in: query
-          name: creatiedatum
-          description: "creatiedatum creatiedatum Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Deze datum verwijst gewoonlijk naar de creatie van het INFORMATIEOBJECT. Het betreft het Dublin Core metadata-element ‘Date’ met als toelichting: Typically, Date will be associated with the creation or availability of the resource. Recommended best practice for encoding the date value is defined in a profile of ISO 8601 (W3CDTF) and includes (among others) dates of the form YYYY-MM-DD. Alle geldige datums gelegen op of voor de huidige datum en tijd"
-          required: false
-          schema:
-            type: string
-            format: date
-        - in: query
-          name: datumingediend
-          description: "De datum waarop het BESLUITVORMINGSSTUK is ingediend"
-          required: false
-          schema:
-            type: string
-            format: date
-        - in: query
-          name: omschrijving
-          description: "De omschrijving van het BESLUITVORMINGSSTUK Dit kan de omschrijving zijn van de MOTIE, het AMENDEMENT of het VOORSTEL"
-          required: false
-          schema:
-            type: string
-        - in: query
-          name: ontvangstdatum
-          description: "ontvangstdatum ontvangstdatum De datum waarop het INFORMATIEOBJECT ontvangen is. De datum waarop het INFORMATIEOBJECT ontvangen is. Het gaat hier om de datum waarop het INFORMATIEOBJECT ontvangen is door de zaakbehandelende organisatie(s), dus niet door een specifieke afdeling of medewerker daarvan. Alle geldige datums gelegen op, voor of na de huidige datum en tijd"
-          required: false
-          schema:
-            type: string
-            format: date
-        - in: query
-          name: taal
-          description: "Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT Het betreft het Dublin Core metadata-element ‘Language’ met als toelichting: Recommended best practice is to use RFC 3066 (RFC3066), which, in conjunction with ISO 639 (ISO639), defines two- and three-letter primary language tags with optional subtags. Examples include “en” or “eng” for English, “akk  for Akkadian, and “en-GB” for English used in the United Kingdom. De Nederlandse taal wordt gecodeerd als “dut”. bij voorkeur ISO 639-2/B"
-          required: false
-          schema:
-            type: string
-            maxLength: 20
-        - in: query
-          name: titel
-          description: "titel titel De naam waaronder het INFORMATIEOBJECT formeel bekend is. De naam waaronder het INFORMATIEOBJECT formeel bekend is. Het betreft het Dublin Core metadata-element ‘Title’ met als toelichting: Typically, Title will be a name by which the resource is formally known. alle alfanumerieke tekens"
-          required: false
-          schema:
-            type: string
-            maxLength: 200
-        - in: query
-          name: toelichting
-          description: "De toelichting op het AMENDEMENT"
-          required: false
-          schema:
-            type: string
-        - in: query
-          name: versie
-          description: "versie versie Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Het gaat hier om een versienummer zoals ‘0.2’ en 1.0’. Ofschoon we er voor gekozen hebben om zowel dit attribuuttype als het attribuuttype Status optioneel te verklaren, ware het aan te bevelen bij elk documemt in ieder geval één van beide attributen van een waarde te voorzien. Nb: De attribuutsoort is in versie 2.0 verplaatst van ENKELVOUDIG INFORMATIEOBJECT naar INFORMATIEOBJECT. Alle alfanumerieke tekens m.u.v. diacrieten"
-          required: false
-          schema:
-            type: string
-            maxLength: 5
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Pagination-Page:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
             X-Pagination-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                type: object
-                properties:
-                  _links:
-                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
-                  _embedded:
-                    type: object
-                    properties:
-                      besluitvormingsstuk:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Besluitvormingsstuk'
+                $ref: '#/components/schemas/AmendementHalCollectie'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
-      - Besluitvormingsstukken
+      - Amendementen
+  /amendementen/{informatieobjectidentificatie}:
+    delete:
+      operationId: Delamendement
+      description: "<body><p>Het bericht dat de JSON/REST API voor het verwijderen van gegevens van een amendement retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+      responses:
+        '200':
+          description: "Verwijderactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+        '204':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/204"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+      tags: 
+      - Amendementen
+    get:
+      operationId: Getamendement
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van gegevens van een amendement retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/AmendementHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Amendementen
     post:
-      operationId: postBesluitvormingsstuk
-      description: "Registreer een besluitvormingsstuk."
+      operationId: postamendementenInformatieobjectidentificatie
+      description: "<body><p>Het vastleggen van een AMENDEMENT</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/AmendementHal'
       responses:
         '201':
-          description: ''
+          description: "OK"
           headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/json:
+            Location:
+              description: "URI van de nieuwe resource"
               schema:
-                $ref: '#/components/schemas/Besluitvormingsstuk'
+                type: string
+                format: uri
+                example: '/amendementen/{informatieobjectidentificatie}/'
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/AmendementHal'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Besluitvormingsstukken
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Besluitvormingsstuk'
-        required: true
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Amendementen
     put:
-      operationId: putBesluitvormingsstuk
-      description: "Wijzig een bestaand Besluitvormingsstuk"
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/Besluitvormingsstuk'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Besluitvormingsstukken
+      operationId: Putamendement
+      description: "<body><p>Het wijzigen van een AGENDAPUNT</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
       requestBody:
         content:
-          application/json:
+          application/hal+json:
             schema:
-              $ref: '#/components/schemas/Besluitvormingsstuk'
-        required: true
-  /besluitvormingsstukken/{informatieobjectidentificatie}:
-    get:
-      operationId: getBesluitvormingsstuk
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een besluitvormingsstuk retourneert."
-      parameters: 
-        - in: path
-          name: informatieobjectidentificatie
-          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
-          required: true
-          schema:
-            type: string
-            maxLength: 40
+                $ref: '#/components/schemas/AmendementHal'
       responses:
         '200':
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/Besluitvormingsstuk'
+                $ref: '#/components/schemas/Amendement'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
-      - Besluitvormingsstukken
-    delete:
-      operationId: delBesluitvormingsstuk
-      description: "Het bericht dat de JSON/REST API voor het verwijderen van een besluitvormingsstuk"
-      parameters: 
-        - in: path
-          name: informatieobjectidentificatie
-          description: "de identificatie van een besluitvormingsstuke"
-          required: true
-          schema:
-            type: string
-            maxLength: 40
-      responses:
-        "204":
-          description: ""
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/problem+json:
-              schema:
-                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-        - Besluitvormingsstukken
+      - Amendementen
   /antwoorden:
     get:
-      operationId: GetAntwoorden
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een collectie antwoorden retourneert."
+      operationId: Getantwoorden
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een collectie antwoorden retourneert.</p></body>"
       parameters: 
         - in: query
           name: page
@@ -1152,56 +861,50 @@ paths:
             minimum: 1
         - in: query
           name: auteur
-          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creëren van de inhoud van het INFORMATIEOBJECT. Het kan zowel een medewerker of organisatorische eenheid van de zaakbehandelende organisatie betreffen als een externe partij (persoon of organisatie). Het betreft het Dublin Core metadata-element ‘Creator’ met als toelichting: Examples of Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity. Van een ontvangen informatieobject kan de afzender de auteur zijn maar dat kan ook een ander zijn bijvoorbeeld in het geval dat de afzender een document van een derde meestuurt. Indien het informatieobject in een geautomatiseerd proces is vervaardigd, dan wordt als auteur vermeld degene die dat informatieobject ondertekend zou hebben dan wel, bij informatieobjecten waarbij van ondertekening geen sprake is (zoals bijvoorbeeld bij het omzetten van de zaakgegevens naar een duurzaam bewaarbaar informatieobject in pdf), degene die verantwoordelijk is voor de inhoud van het informatieobject vanuit zijn of haar rol bij de zaak (veelal degene in de rol van Zaakcoördinator). De naamgegevens van de auteur zijnde een betrokkene die in een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur niet in een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk persoon of organisatie zijnde de auteur. In het laatste geval verdient het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap wordt uitgeoefend."
+          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creÃ«ren van de inhoud van het INFORMATIEOBJECT. Het kan zowel een medewerker of organisatorische eenheid van de zaakbehandelende organisatie betreffen als een externe partij (persoon of organisatie). Het betreft het Dublin Core metadata-element â€˜Creatorâ€™ met als toelichting: Examples of Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity. Van een ontvangen informatieobject kan de afzender de auteur zijn maar dat kan ook een ander zijn bijvoorbeeld in het geval dat de afzender een document van een derde meestuurt. Indien het informatieobject in een geautomatiseerd proces is vervaardigd, dan wordt als auteur vermeld degene die dat informatieobject ondertekend zou hebben dan wel, bij informatieobjecten waarbij van ondertekening geen sprake is (zoals bijvoorbeeld bij het omzetten van de zaakgegevens naar een duurzaam bewaarbaar informatieobject in pdf), degene die verantwoordelijk is voor de inhoud van het informatieobject vanuit zijn of haar rol bij de zaak (veelal degene in de rol van ZaakcoÃ¶rdinator). De naamgegevens van de auteur zijnde een betrokkene die in een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur niet in een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk persoon of organisatie zijnde de auteur. In het laatste geval verdient het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap wordt uitgeoefend."
           required: false
           schema:
             type: string
             maxLength: 200
         - in: query
           name: bronorganisatie
-          description: "bronorganisatie bronorganisatie Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Het betreft het RSIN (Rechtspersonen en Samenwerkingsverbanden InformatieNummer) zoals dat door de KvK in het NHR aan elk rechtspersoon en samenwerkingsverband is toegekend. Dit identificeert uniek de organisatie, zijnde een rechtspersoon of samenwerkingsverband, dat het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Met het laatste doelen we er op dat bij uitwisseling van een informatieobject tussen samenwerkende organisaties de unieke aanduiding van het informatieobject niet wijzigt mits de ontvangende organisatie geen wijzigingen in het informatieobject aanbrengt. In het laatste geval ontstaat een nieuw informatieobject. Het RSIN staat in het Handelsregister (NHR) en op het daaraan te ontlenen uittreksel. Deze attribuutsoort vormt tezamen met de Informatieobjectidentificatie de unieke aanduiding van een informatieobject voor geheel Nederland. De waarde van dit attribuutsoort wijzigt niet, ook niet indien (de behandeling van) het informatieobject over zou gaan naar een andere organisatie. Er is immers maar één organisatie die het informatieobject gecreëerd of als eerste vastgelegd heeft. De in het NHR voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden."
+          description: "bronorganisatie bronorganisatie Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Het betreft het RSIN (Rechtspersonen en Samenwerkingsverbanden InformatieNummer) zoals dat door de KvK in het NHR aan elk rechtspersoon en samenwerkingsverband is toegekend. Dit identificeert uniek de organisatie, zijnde een rechtspersoon of samenwerkingsverband, dat het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Met het laatste doelen we er op dat bij uitwisseling van een informatieobject tussen samenwerkende organisaties de unieke aanduiding van het informatieobject niet wijzigt mits de ontvangende organisatie geen wijzigingen in het informatieobject aanbrengt. In het laatste geval ontstaat een nieuw informatieobject. Het RSIN staat in het Handelsregister (NHR) en op het daaraan te ontlenen uittreksel. Deze attribuutsoort vormt tezamen met de Informatieobjectidentificatie de unieke aanduiding van een informatieobject voor geheel Nederland. De waarde van dit attribuutsoort wijzigt niet, ook niet indien (de behandeling van) het informatieobject over zou gaan naar een andere organisatie. Er is immers maar Ã©Ã©n organisatie die het informatieobject gecreÃ«erd of als eerste vastgelegd heeft. De in het NHR voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden."
           required: false
           schema:
             type: integer
             maximum: 9.99999999E8
         - in: query
           name: creatiedatum
-          description: "creatiedatum creatiedatum Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Deze datum verwijst gewoonlijk naar de creatie van het INFORMATIEOBJECT. Het betreft het Dublin Core metadata-element ‘Date’ met als toelichting: Typically, Date will be associated with the creation or availability of the resource. Recommended best practice for encoding the date value is defined in a profile of ISO 8601 (W3CDTF) and includes (among others) dates of the form YYYY-MM-DD. Alle geldige datums gelegen op of voor de huidige datum en tijd"
+          description: "creatiedatum creatiedatum Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Deze datum verwijst gewoonlijk naar de creatie van het INFORMATIEOBJECT. Het betreft het Dublin Core metadata-element â€˜Dateâ€™ met als toelichting: Typically, Date will be associated with the creation or availability of the resource. Recommended best practice for encoding the date value is defined in a profile of ISO 8601 (W3CDTF) and includes (among others) dates of the form YYYY-MM-DD. Alle geldige datums gelegen op of voor de huidige datum en tijd"
           required: false
           schema:
             type: string
             format: date
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
         - in: query
           name: informatieobjectidentificatie
-          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
           required: false
           schema:
             type: string
             maxLength: 40
         - in: query
-          name: ontvangstdatum
-          description: "ontvangstdatum ontvangstdatum De datum waarop het INFORMATIEOBJECT ontvangen is. De datum waarop het INFORMATIEOBJECT ontvangen is. Het gaat hier om de datum waarop het INFORMATIEOBJECT ontvangen is door de zaakbehandelende organisatie(s), dus niet door een specifieke afdeling of medewerker daarvan. Alle geldige datums gelegen op, voor of na de huidige datum en tijd"
-          required: false
-          schema:
-            type: string
-            format: date
-        - in: query
           name: taal
-          description: "Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT Het betreft het Dublin Core metadata-element ‘Language’ met als toelichting: Recommended best practice is to use RFC 3066 (RFC3066), which, in conjunction with ISO 639 (ISO639), defines two- and three-letter primary language tags with optional subtags. Examples include “en” or “eng” for English, “akk  for Akkadian, and “en-GB” for English used in the United Kingdom. De Nederlandse taal wordt gecodeerd als “dut”. bij voorkeur ISO 639-2/B"
+          description: "Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT Het betreft het Dublin Core metadata-element â€˜Languageâ€™ met als toelichting: Recommended best practice is to use RFC 3066 (RFC3066), which, in conjunction with ISO 639 (ISO639), defines two- and three-letter primary language tags with optional subtags. Examples include â€œenâ€? or â€œengâ€? for English, â€œakk  for Akkadian, and â€œen-GBâ€? for English used in the United Kingdom. De Nederlandse taal wordt gecodeerd als â€œdutâ€?. bij voorkeur ISO 639-2/B"
           required: false
           schema:
             type: string
             maxLength: 20
         - in: query
           name: titel
-          description: "titel titel De naam waaronder het INFORMATIEOBJECT formeel bekend is. De naam waaronder het INFORMATIEOBJECT formeel bekend is. Het betreft het Dublin Core metadata-element ‘Title’ met als toelichting: Typically, Title will be a name by which the resource is formally known. alle alfanumerieke tekens"
+          description: "titel titel De naam waaronder het INFORMATIEOBJECT formeel bekend is. De naam waaronder het INFORMATIEOBJECT formeel bekend is. Het betreft het Dublin Core metadata-element â€˜Titleâ€™ met als toelichting: Typically, Title will be a name by which the resource is formally known. alle alfanumerieke tekens"
           required: false
           schema:
             type: string
             maxLength: 200
         - in: query
           name: versie
-          description: "versie versie Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Het gaat hier om een versienummer zoals ‘0.2’ en 1.0’. Ofschoon we er voor gekozen hebben om zowel dit attribuuttype als het attribuuttype Status optioneel te verklaren, ware het aan te bevelen bij elk documemt in ieder geval één van beide attributen van een waarde te voorzien. Nb: De attribuutsoort is in versie 2.0 verplaatst van ENKELVOUDIG INFORMATIEOBJECT naar INFORMATIEOBJECT. Alle alfanumerieke tekens m.u.v. diacrieten"
+          description: "versie versie Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Het gaat hier om een versienummer zoals â€˜0.2â€™ en 1.0â€™. Ofschoon we er voor gekozen hebben om zowel dit attribuuttype als het attribuuttype Status optioneel te verklaren, ware het aan te bevelen bij elk documemt in ieder geval Ã©Ã©n van beide attributen van een waarde te voorzien. Nb: De attribuutsoort is in versie 2.0 verplaatst van ENKELVOUDIG INFORMATIEOBJECT naar INFORMATIEOBJECT. Alle alfanumerieke tekens m.u.v. diacrieten"
           required: false
           schema:
             type: string
@@ -1211,337 +914,247 @@ paths:
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Pagination-Page:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
             X-Pagination-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                type: object
-                properties:
-                  _links:
-                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
-                  _embedded:
-                    type: object
-                    properties:
-                      antwoorden:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Antwoord'
+                $ref: '#/components/schemas/AntwoordHalCollectie'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Antwoorden
+  /antwoorden/{informatieobjectidentificatie}:
+    delete:
+      operationId: delantwoord
+      description: "<body><p>Het bericht dat de JSON/REST API voor het verwijderen van gegevens van een antwoord.</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+      responses:
+        '200':
+          description: "Verwijderactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+        '204':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/204"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+      tags: 
+      - Antwoorden
+    get:
+      operationId: Getantwoord
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een antwoord retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/AntwoordHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
       - Antwoorden
     post:
-      operationId: postAntwoord
-      description: "Registreer een antwoord."
+      operationId: postantwoord
+      description: "<body><p>Het vastleggen van een ANTWOORD</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/AntwoordHal'
       responses:
         '201':
-          description: ''
+          description: "OK"
           headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/json:
+            Location:
+              description: "URI van de nieuwe resource"
               schema:
-                $ref: '#/components/schemas/Antwoord'
+                type: string
+                format: uri
+                example: '/antwoorden/{informatieobjectidentificatie}/'
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/AntwoordHal'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
-      tags:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
       - Antwoorden
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Antwoord'
-        required: true
     put:
-      operationId: putAntwoord
-      description: "Wijzig een bestaand Antwoord"
+      operationId: putantwoord
+      description: "<body><p>Het wijzigen van een antwoord.</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/AntwoordHal'
       responses:
         '200':
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/Antwoord'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Antwoorden
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Antwoord'
-        required: true
-  /antwoorden/{informatieobjectidentificatie}:
-    get:
-      operationId: getAntwoord
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een antwoord retourneert."
-      parameters: 
-        - in: path
-          name: informatieobjectidentificatie
-          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
-          required: true
-          schema:
-            type: string
-            maxLength: 40
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/Antwoord'
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
       - Antwoorden
-    delete:
-      operationId: delAntwoord
-      description: "Het bericht dat de JSON/REST API voor het verwijderen van een antwoord"
-      parameters: 
-        - in: path
-          name: informatieobjectidentificatie
-          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
-          required: true
-          schema:
-            type: string
-            maxLength: 40
-      responses:
-        "204":
-          description: ""
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/problem+json:
-              schema:
-                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-        - Antwoorden
-  /besluiten/{besluitidentificatie}:
-    get:
-      operationId: getBesluit
-      description: "Het bericht dat de JSON/REST API voor het ophalen van besluit gegevens retourneert."
-      parameters: 
-        - in: path
-          name: besluitidentificatie
-          description: "Identificatie van het besluit binnen de organisatie die het besluit heeft vastgesteld. Identificatie van het besluit binnen de organisatie die het besluit heeft vastgesteld. Het betreft de identificatie of ook wel nummer dat aan het besluit is toegekend door de organisatie die het besluit heeft vastgesteld. Dit identificeert een besluit uniek binnen de desbetreffende organisatie en kan worden gebruikt om snel te kunnen refereren aan een bepaald besluit in mondelinge en schriftelijke communicatie. Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Verantwoordelijke organisatie’, wordt een unieke aanduiding van een besluit voor geheel Nederland verkregen. Het betreft de attribuutsoort Beschikkingidentificatie in het GFO Zaken 2004.organisatie. Er is immers maar één organisatie die de zaak gecreëerd heeft. Alle alfanumerieke tekens m.u.v. diacrieten"
-          required: true
-          schema:
-            type: string
-            maxLength: 50
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/Besluit'
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-      - Besluiten
-    delete:
-      operationId: delBesluit
-      description: "Het bericht dat de JSON/REST API voor het verwijderen van een Besluit"
-      parameters: 
-        - in: path
-          name: besluitidentificatie
-          description: "Identificatie van het besluit binnen de organisatie die het besluit heeft vastgesteld. Identificatie van het besluit binnen de organisatie die het besluit heeft vastgesteld. Het betreft de identificatie of ook wel nummer dat aan het besluit is toegekend door de organisatie die het besluit heeft vastgesteld. Dit identificeert een besluit uniek binnen de desbetreffende organisatie en kan worden gebruikt om snel te kunnen refereren aan een bepaald besluit in mondelinge en schriftelijke communicatie. Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Verantwoordelijke organisatie’, wordt een unieke aanduiding van een besluit voor geheel Nederland verkregen. Het betreft de attribuutsoort Beschikkingidentificatie in het GFO Zaken 2004.organisatie. Er is immers maar één organisatie die de zaak gecreëerd heeft. Alle alfanumerieke tekens m.u.v. diacrieten"
-          required: true
-          schema:
-            type: string
-            maxLength: 50
-      responses:
-        "204":
-          description: ""
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/problem+json:
-              schema:
-                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-        - Besluiten
   /besluiten:
     get:
-      operationId: getBesluiten
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een collectie besluiten retourneert."
+      operationId: Getbesluiten
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een collectie besluiten retourneert.</p></body>"
       parameters: 
         - in: query
           name: page
@@ -1551,220 +1164,842 @@ paths:
             type: integer
             minimum: 1
         - in: query
-          name: besluitdatum
-          description: "De beslisdatum (AWB) van het besluit. De beslisdatum (AWB) van het besluit. Het betreft de attribuutsoort Beschikkingsdatum in het GFO Zaken 2004. Alle geldige datums gelegen op of voor de huidige datum en tijd"
-          required: false
-          schema:
-            type: string
-            format: date
-        - in: query
           name: besluittoelichting
-          description: "Toelichting bij het besluit. Toelichting bij het besluit. De (samenvatting van de) toelichting op het besluit zoals veelal vermeld in de besluittekst. Het betreft de attribuutsoort Beschikkingtoelichting in het GFO Zaken 2004. alle alfanumerieke tekens"
+          description: "Het resultaat van het BESLUIT Toelichting bij het besluit. alle alfanumerieke tekens"
           required: false
           schema:
             type: string
-            maxLength: 1000
-        - in: query
-          name: bestuursorgaan
-          description: "Een orgaan van een rechtspersoon krachtens publiekrecht ingesteld of een persoon of college, met enig openbaar gezag bekleed onder wiens verantwoordelijkheid het besluit vastgesteld is. Een orgaan van een rechtspersoon krachtens publiekrecht ingesteld of een persoon of college, met enig openbaar gezag bekleed onder wiens verantwoordelijkheid het besluit vastgesteld is. Het vastleggen van het bestuursorgaan onder wiens verantwoordelijkheid het besluit vastgesteld is, is vooral relevant indien de besluitvorming gemandateerd is aan een andere organisatie. Bijvoorbeeld een gemeente die de behandeling van milieuvergunningaanvragen heeft gemandateerd aan een Regionale UitvoeringsDienst (of Omgevingsdienst). Zie regels attribuutsoort"
-          required: false
+            maxLength: 200
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Pagination-Page:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
+            X-Pagination-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/BesluitHalCollectie'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Besluiten
+  /besluiten/{besluitidentificatie}:
+    delete:
+      operationId: delbesluit
+      description: "<body><p>Het bericht dat de JSON/REST API voor het verwijderen van gegevens van een besluit.</p></body>"
+      parameters: 
+        - in: path
+          name: besluitidentificatie
+          description: "Identificatie van het besluit binnen de organisatie die het besluit heeft vastgesteld. Identificatie van het besluit binnen de organisatie die het besluit heeft vastgesteld. Het betreft de identificatie of ook wel nummer dat aan het besluit is toegekend door de organisatie die het besluit heeft vastgesteld. Dit identificeert een besluit uniek binnen de desbetreffende organisatie en kan worden gebruikt om snel te kunnen refereren aan een bepaald besluit in mondelinge en schriftelijke communicatie. Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Verantwoordelijke organisatieâ€™, wordt een unieke aanduiding van een besluit voor geheel Nederland verkregen. Het betreft de attribuutsoort Beschikkingidentificatie in het GFO Zaken 2004.organisatie. Er is immers maar Ã©Ã©n organisatie die de zaak gecreÃ«erd heeft. Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
           schema:
             type: string
             maxLength: 50
+      responses:
+        '200':
+          description: "Verwijderactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+        '204':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/204"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+      tags: 
+      - Besluiten
+    get:
+      operationId: Getbesluit
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van besluit gegevens retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: besluitidentificatie
+          description: "Identificatie van het besluit binnen de organisatie die het besluit heeft vastgesteld. Identificatie van het besluit binnen de organisatie die het besluit heeft vastgesteld. Het betreft de identificatie of ook wel nummer dat aan het besluit is toegekend door de organisatie die het besluit heeft vastgesteld. Dit identificeert een besluit uniek binnen de desbetreffende organisatie en kan worden gebruikt om snel te kunnen refereren aan een bepaald besluit in mondelinge en schriftelijke communicatie. Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Verantwoordelijke organisatieâ€™, wordt een unieke aanduiding van een besluit voor geheel Nederland verkregen. Het betreft de attribuutsoort Beschikkingidentificatie in het GFO Zaken 2004.organisatie. Er is immers maar Ã©Ã©n organisatie die de zaak gecreÃ«erd heeft. Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 50
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/BesluitHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Besluiten
+    post:
+      operationId: postbesluitenBesluitidentificatie
+      description: "<body><p>Het vastleggen van een BESLUIT</p></body>"
+      parameters: 
+        - in: path
+          name: besluitidentificatie
+          description: "Identificatie van het besluit binnen de organisatie die het besluit heeft vastgesteld. Identificatie van het besluit binnen de organisatie die het besluit heeft vastgesteld. Het betreft de identificatie of ook wel nummer dat aan het besluit is toegekend door de organisatie die het besluit heeft vastgesteld. Dit identificeert een besluit uniek binnen de desbetreffende organisatie en kan worden gebruikt om snel te kunnen refereren aan een bepaald besluit in mondelinge en schriftelijke communicatie. Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Verantwoordelijke organisatieâ€™, wordt een unieke aanduiding van een besluit voor geheel Nederland verkregen. Het betreft de attribuutsoort Beschikkingidentificatie in het GFO Zaken 2004.organisatie. Er is immers maar Ã©Ã©n organisatie die de zaak gecreÃ«erd heeft. Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 50
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/BesluitHal'
+      responses:
+        '201':
+          description: "OK"
+          headers:
+            Location:
+              description: "URI van de nieuwe resource"
+              schema:
+                type: string
+                format: uri
+                example: '/besluiten/{besluitidentificatie}/'
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/BesluitHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Besluiten
+    put:
+      operationId: PutBestuit
+      description: "<body><p>Het wijzigen van een BESLUIT</p></body>"
+      parameters: 
+        - in: path
+          name: besluitidentificatie
+          description: "Identificatie van het besluit binnen de organisatie die het besluit heeft vastgesteld. Identificatie van het besluit binnen de organisatie die het besluit heeft vastgesteld. Het betreft de identificatie of ook wel nummer dat aan het besluit is toegekend door de organisatie die het besluit heeft vastgesteld. Dit identificeert een besluit uniek binnen de desbetreffende organisatie en kan worden gebruikt om snel te kunnen refereren aan een bepaald besluit in mondelinge en schriftelijke communicatie. Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Verantwoordelijke organisatieâ€™, wordt een unieke aanduiding van een besluit voor geheel Nederland verkregen. Het betreft de attribuutsoort Beschikkingidentificatie in het GFO Zaken 2004.organisatie. Er is immers maar Ã©Ã©n organisatie die de zaak gecreÃ«erd heeft. Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 50
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/BesluitHal'
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/Besluit'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Besluiten
+  /besluitvormingsstukken:
+    get:
+      operationId: Getbesluitvormingsstukken
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een collectie besluitvormingsstukken retourneert.</p></body>"
+      parameters: 
         - in: query
-          name: ingangsdatum
-          description: "Ingangsdatum van de werkingsperiode van het besluit. Ingangsdatum van de werkingsperiode van het besluit. Het betreft de attribuutsoort Ingangsdatum (van BESCHIKKING) in het GFO Zaken 2004. Alle geldige datums zowel op, voor of na de huidige datum en tijd"
+          name: page
+          description: "Een pagina binnen de gepagineerde resultatenset."
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+        - in: query
+          name: auteur
+          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creÃ«ren van de inhoud van het INFORMATIEOBJECT. Het kan zowel een medewerker of organisatorische eenheid van de zaakbehandelende organisatie betreffen als een externe partij (persoon of organisatie). Het betreft het Dublin Core metadata-element â€˜Creatorâ€™ met als toelichting: Examples of Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity. Van een ontvangen informatieobject kan de afzender de auteur zijn maar dat kan ook een ander zijn bijvoorbeeld in het geval dat de afzender een document van een derde meestuurt. Indien het informatieobject in een geautomatiseerd proces is vervaardigd, dan wordt als auteur vermeld degene die dat informatieobject ondertekend zou hebben dan wel, bij informatieobjecten waarbij van ondertekening geen sprake is (zoals bijvoorbeeld bij het omzetten van de zaakgegevens naar een duurzaam bewaarbaar informatieobject in pdf), degene die verantwoordelijk is voor de inhoud van het informatieobject vanuit zijn of haar rol bij de zaak (veelal degene in de rol van ZaakcoÃ¶rdinator). De naamgegevens van de auteur zijnde een betrokkene die in een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur niet in een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk persoon of organisatie zijnde de auteur. In het laatste geval verdient het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap wordt uitgeoefend."
           required: false
           schema:
             type: string
-            format: date
+            maxLength: 200
         - in: query
-          name: publicatiedatum
-          description: "Datum waarop het besluit gepubliceerd wordt. Datum waarop het besluit gepubliceerd wordt. Het betreft de attribuutsoort Publicatiedatum (van BESCHIKKING) in het GFO Zaken 2004. Alle geldige datums zowel op, voor of na de huidige datum en tijd"
-          required: false
-          schema:
-            type: string
-            format: date
-        - in: query
-          name: uiterlijkereactiedatum
-          description: "De datum tot wanneer verweer tegen het besluit mogelijk is. De datum tot wanneer verweer tegen het besluit mogelijk is. De reactiedatum valt op zich af te leiden met behulp van andere attributen zoals Besluittype.Reactietermijn en Besluitdatum. De reactiedatum is hier als attribuutsoort opgenomen om deze datum expliciet te kunnen communiceren. Zodoende hoeven partijen niet telkens deze datum zelf af te leiden (rekening houdend met weekend- en feestdagen) en hoeven zij niet te beschikken over de desbetreffende besluittype-attributen. Alle geldige datums zowel op, voor of na de huidige datum en tijd"
-          required: false
-          schema:
-            type: string
-            format: date
-        - in: query
-          name: verantwoordelijkeorganisatie
-          description: "Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het besluit heeft vastgesteld. Het betreft het RSIN (Rechtspersonen en Samenwerkingsverbanden InformatieNummer) zoals dat door de KvK in het NHR aan elk rechtspersoon en samenwerkingsverband is toegekend. Dit identificeert uniek de organisatie, zijnde een rechtspersoon of samenwerkingsverband, die het besluit heeft vastgesteld. Dit zal veelal dezelfde organisatie zijn als vastgelegd bij de zaak in Verantwoordelijke organisatie. Het RSIN staat in het Handelsregister (NHR) en op het daaraan te ontlenen uittreksel. De in het NHR voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden."
+          name: bronorganisatie
+          description: "bronorganisatie bronorganisatie Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Het betreft het RSIN (Rechtspersonen en Samenwerkingsverbanden InformatieNummer) zoals dat door de KvK in het NHR aan elk rechtspersoon en samenwerkingsverband is toegekend. Dit identificeert uniek de organisatie, zijnde een rechtspersoon of samenwerkingsverband, dat het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Met het laatste doelen we er op dat bij uitwisseling van een informatieobject tussen samenwerkende organisaties de unieke aanduiding van het informatieobject niet wijzigt mits de ontvangende organisatie geen wijzigingen in het informatieobject aanbrengt. In het laatste geval ontstaat een nieuw informatieobject. Het RSIN staat in het Handelsregister (NHR) en op het daaraan te ontlenen uittreksel. Deze attribuutsoort vormt tezamen met de Informatieobjectidentificatie de unieke aanduiding van een informatieobject voor geheel Nederland. De waarde van dit attribuutsoort wijzigt niet, ook niet indien (de behandeling van) het informatieobject over zou gaan naar een andere organisatie. Er is immers maar Ã©Ã©n organisatie die het informatieobject gecreÃ«erd of als eerste vastgelegd heeft. De in het NHR voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden."
           required: false
           schema:
             type: integer
             maximum: 9.99999999E8
         - in: query
-          name: vervaldatum
-          description: "Datum waarop de werkingsperiode van het besluit eindigt. Datum waarop de werkingsperiode van het besluit eindigt. De werkingsperiode is inclusief de opgeven datum. Het betreft de attribuutsoort Vervaldatum (van BESCHIKKING) in het GFO Zaken 2004. Alle geldige datums zowel op, voor of na de huidige datum en tijd"
+          name: creatiedatum
+          description: "creatiedatum creatiedatum Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Deze datum verwijst gewoonlijk naar de creatie van het INFORMATIEOBJECT. Het betreft het Dublin Core metadata-element â€˜Dateâ€™ met als toelichting: Typically, Date will be associated with the creation or availability of the resource. Recommended best practice for encoding the date value is defined in a profile of ISO 8601 (W3CDTF) and includes (among others) dates of the form YYYY-MM-DD. Alle geldige datums gelegen op of voor de huidige datum en tijd"
           required: false
           schema:
             type: string
             format: date
         - in: query
-          name: vervalreden
-          description: "De omschrijving die aangeeft op grond waarvan het besluit is of komt te vervallen. De omschrijving die aangeeft op grond waarvan het besluit is of komt te vervallen. De attribuutsoort geeft aan wat de reden is van het vervallen van het besluit op de vervaldatum. Het kan zijn dat het besluit slechts voor een beperkte periode geldig is. Dan zal de vervaldatum veelal al bij de creatie van het besluit bekend zijn. Het kan ook zijn dat het besluit later ingetrokken is, bijvoorbeeld vanwege gewijizigde omstandigheden (de betrokkene op wie het besluit van toepassing is, is overleden) of vanwege een toegekend bezwaar. In die gevallen is er veelal een gerelateerde zaak die onder meer tot gevolg heeft dat het besluit ingetrokken is."
-          required: false
-          schema:
-              $ref: "#/components/schemas/Vervalreden"
-        - in: query
-          name: verzenddatum
-          description: "Datum waarop het besluit verzonden is. Datum waarop het besluit verzonden is. Het betreft de attribuutsoort Verzenddatum (van BESCHIKKING) in het GFO Zaken 2004. Alle geldige datums zowel op, voor of na de huidige datum en tijd"
+          name: datumingediend
+          description: "De datum waarop het BESLUITVORMINGSSTUK is ingediend"
           required: false
           schema:
             type: string
             format: date
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
+        - in: query
+          name: omschrijving
+          description: "De omschrijving van het BESLUITVORMINGSSTUK Dit kan de omschrijving zijn van de MOTIE, het AMENDEMENT of het VOORSTEL"
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: taal
+          description: "Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT Het betreft het Dublin Core metadata-element â€˜Languageâ€™ met als toelichting: Recommended best practice is to use RFC 3066 (RFC3066), which, in conjunction with ISO 639 (ISO639), defines two- and three-letter primary language tags with optional subtags. Examples include â€œenâ€? or â€œengâ€? for English, â€œakk  for Akkadian, and â€œen-GBâ€? for English used in the United Kingdom. De Nederlandse taal wordt gecodeerd als â€œdutâ€?. bij voorkeur ISO 639-2/B"
+          required: false
+          schema:
+            type: string
+            maxLength: 20
+        - in: query
+          name: titel
+          description: "titel titel De naam waaronder het INFORMATIEOBJECT formeel bekend is. De naam waaronder het INFORMATIEOBJECT formeel bekend is. Het betreft het Dublin Core metadata-element â€˜Titleâ€™ met als toelichting: Typically, Title will be a name by which the resource is formally known. alle alfanumerieke tekens"
+          required: false
+          schema:
+            type: string
+            maxLength: 200
+        - in: query
+          name: toelichting
+          description: "De toelichting op het AMENDEMENT"
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: versie
+          description: "versie versie Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Het gaat hier om een versienummer zoals â€˜0.2â€™ en 1.0â€™. Ofschoon we er voor gekozen hebben om zowel dit attribuuttype als het attribuuttype Status optioneel te verklaren, ware het aan te bevelen bij elk documemt in ieder geval Ã©Ã©n van beide attributen van een waarde te voorzien. Nb: De attribuutsoort is in versie 2.0 verplaatst van ENKELVOUDIG INFORMATIEOBJECT naar INFORMATIEOBJECT. Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: false
+          schema:
+            type: string
+            maxLength: 5
       responses:
         '200':
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Pagination-Page:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
             X-Pagination-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                type: object
-                properties:
-                  _links:
-                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
-                  _embedded:
-                    type: object
-                    properties:
-                      besluiten:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Besluit'
+                $ref: '#/components/schemas/BesluitvormingsstukHalCollectie'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
-      - Besluiten
+      - Besluitvormingsstukken
+  /besluitvormingsstukken/{informatieobjectidentificatie}:
+    delete:
+      operationId: delbesluitvormingsstuk
+      description: "<body><p>Het bericht dat de JSON/REST API voor het verwijderen van gegevens van een besluitvormingsstuk.</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+      responses:
+        '200':
+          description: "Verwijderactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+        '204':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/204"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+      tags: 
+      - Besluitvormingsstukken
+    get:
+      operationId: Getbesluitvormingsstuk
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een besluitvormingsstuk retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/BesluitvormingsstukHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Besluitvormingsstukken
     post:
-      operationId: postBesluit
-      description: "Registreer een Besluit."
+      operationId: postbesluitvormingsstukkenInformatieobjectidentificatie
+      description: "<body><p>Het vastleggen van een BESLUITVORMINGSSTUK</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/BesluitvormingsstukHal'
       responses:
         '201':
-          description: ''
+          description: "OK"
           headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/json:
+            Location:
+              description: "URI van de nieuwe resource"
               schema:
-                $ref: '#/components/schemas/Besluit'
+                type: string
+                format: uri
+                example: '/besluitvormingsstukken/{informatieobjectidentificatie}/'
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/BesluitvormingsstukHal'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Besluiten
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Besluitvormingsstukken
+    put:
+      operationId: PutBestuitvormingsstuk
+      description: "<body><p>Het wijzigen van een BESLUITVORMINGSSTUK</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
       requestBody:
         content:
-          application/json:
+          application/hal+json:
             schema:
-              $ref: '#/components/schemas/Besluit'
-        required: true
-    put:
-      operationId: putBesluit
-      description: "Wijzig een bestaand Besluit"
+                $ref: '#/components/schemas/BesluitvormingsstukHal'
       responses:
         '200':
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/Besluit'
+                $ref: '#/components/schemas/Besluitvormingsstuk'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Besluiten
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Besluitvormingsstukken
+  /dagelijksbestuurlidmaatschappen:
+    get:
+      operationId: Getdagelijksbestuurlidmaatschappen
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van lidmaatschappen van het dagelijks bestuur retourneert.</p></body>"
+      parameters: 
+        - in: query
+          name: page
+          description: "Een pagina binnen de gepagineerde resultatenset."
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+        - in: query
+          name: datumbegindagelijksbestuurlidmaatschap
+          description: "De datum en tijdstip waarop het lidmaatschap van het dagelijkse bestuur begon"
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: datumeindedagelijksbestuurlidmaatschap
+          description: "De datum en tijdstip waarop het lidmaatschap van het dagelijkse bestuur geÃ«indigd is."
+          required: false
+          schema:
+            type: string
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Pagination-Page:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
+            X-Pagination-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/DagelijksBestuurLidmaatschapHalCollectie'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Dagelijksbestuurlidmaatschappen
+  /dagelijksbestuurlidmaatschappen/{dagelijksbestuurlidmaatschapidentificatie}:
+    delete:
+      operationId: Deldagelijksbestuurlidmaatschappen
+      description: "<body><p>Het bericht dat de JSON/REST API voor het verwijderen van lidmaatschappen van het dagelijks bestuur.</p></body>"
+      parameters: 
+        - in: path
+          name: dagelijksbestuurlidmaatschapidentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+      responses:
+        '200':
+          description: "Verwijderactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+        '204':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/204"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+      tags: 
+      - Dagelijksbestuurlidmaatschappen
+    get:
+      operationId: Getdagelijksbestuurlidmaatschap
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van lidmaatschappen van het dagelijks bestuur retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: dagelijksbestuurlidmaatschapidentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/DagelijksBestuurLidmaatschapHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Dagelijksbestuurlidmaatschappen
+    post:
+      operationId: putdagelijksbetuurlidmaatschappen
+      description: "<body><p>Het vastleggen van een BESLUIT</p></body>"
+      parameters: 
+        - in: path
+          name: dagelijksbestuurlidmaatschapidentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+            maxLength: 10
       requestBody:
         content:
-          application/json:
+          application/hal+json:
             schema:
-              $ref: '#/components/schemas/Besluit'
-        required: true
+                $ref: '#/components/schemas/DagelijksBestuurLidmaatschapHal'
+      responses:
+        '201':
+          description: "OK"
+          headers:
+            Location:
+              description: "URI van de nieuwe resource"
+              schema:
+                type: string
+                format: uri
+                example: '/dagelijksbestuurlidmaatschappen/{dagelijksbestuurlidmaatschapidentificatie}/'
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/DagelijksBestuurLidmaatschapHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Dagelijksbestuurlidmaatschappen
+    put:
+      operationId: Putdagelijksbestuurlidmaatschap
+      description: "<body><p>Het wijzigen van een DAGELIJKS BESTUUR</p></body>"
+      parameters: 
+        - in: path
+          name: dagelijksbestuurlidmaatschapidentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/DagelijksBestuurLidmaatschapHal'
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/DagelijksBestuurLidmaatschap'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Dagelijksbestuurlidmaatschappen
   /dagelijksebesturen:
     get:
-      operationId: getDagelijkseBesturen
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een collectie dagelijkse besturen retourneert."
+      operationId: Getdagelijksebesturen
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een collectie dagelijkse besturen retourneert.</p></body>"
       parameters: 
         - in: query
           name: page
@@ -1780,152 +2015,57 @@ paths:
           schema:
             type: string
             maxLength: 200
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
       responses:
         '200':
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Pagination-Page:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
             X-Pagination-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                type: object
-                properties:
-                  _links:
-                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
-                  _embedded:
-                    type: object
-                    properties:
-                      dagelijksebesturen:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/DagelijksBestuur'
+                $ref: '#/components/schemas/DagelijksBestuurHalCollectie'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
       - Dagelijkse Besturen
-    post:
-      operationId: postDagelijksBestuur
-      description: "Registreer een DagelijksBestuur."
-      responses:
-        '201':
-          description: ''
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DagelijksBestuur'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Dagelijkse Besturen
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DagelijksBestuur'
-        required: true
-    put:
-      operationId: putDagelijksBestuur
-      description: "Wijzig een bestaand DagelijksBestuur Als de wijziging het verwijderen van een DagelijksBestuurLidmaatschap inhoudt is het de taak van de provider om gerelateerde DagelijksBestuurlidmaatschap(pen). te verwijderen "
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/DagelijksBestuur'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Dagelijkse Besturen
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DagelijksBestuur'
-        required: true
   /dagelijksebesturen/{dagelijksbestuuridentificatie}:
-    get:
-      operationId: getDagelijksBestuur
-      description: "Het bericht dat de JSON/REST API voor het ophalen van dagelijks bestuur gegevens retourneert."
+    delete:
+      operationId: deldagelijksbestuur
+      description: "<body><p>Het bericht dat de JSON/REST API voor het verwijderen van gegevens van een dagelijksbestuur</p></body>"
       parameters: 
         - in: path
           name: dagelijksbestuuridentificatie
@@ -1936,510 +2076,192 @@ paths:
             maxLength: 10
       responses:
         '200':
+          description: "Verwijderactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+        '204':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/204"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+      tags: 
+      - Dagelijkse Besturen
+    get:
+      operationId: Getdagelijksbestuur
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van dagelijks bestuur gegevens retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: dagelijksbestuuridentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
+      responses:
+        '200':
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/DagelijksBestuurHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Dagelijkse Besturen
+    post:
+      operationId: postdagelijksebesturenDagelijksbestuuridentificatie
+      description: "<body><p>Het vastleggen van een BESLUIT</p></body>"
+      parameters: 
+        - in: path
+          name: dagelijksbestuuridentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/DagelijksBestuurHal'
+      responses:
+        '201':
+          description: "OK"
+          headers:
+            Location:
+              description: "URI van de nieuwe resource"
+              schema:
+                type: string
+                format: uri
+                example: '/dagelijksebesturen/{dagelijksbestuuridentificatie}/'
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/DagelijksBestuurHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Dagelijkse Besturen
+    put:
+      operationId: Putdagelijksbestuur
+      description: "<body><p>Het wijzigen van een DAGELIJKS BESTUUR</p></body>"
+      parameters: 
+        - in: path
+          name: dagelijksbestuuridentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/DagelijksBestuurHal'
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/DagelijksBestuur'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
       - Dagelijkse Besturen
-    delete:
-      operationId: delDagelijksBestuur
-      description: "Het bericht dat de JSON/REST API voor het verwijderen van een DAGELIJKSBESTUUR. Bij het verwijderen van een DAGELIJKSBESTUUR is het de taak van de provider de gerelateerde DaAGELIJKSBESTUURLIDMAATSCHAPen te verwijderen middels om een cascade-delete. "
-      parameters: 
-        - in: path
-          name: dagelijksbestuuridentificatie
-          description: ""
-          required: true
-          schema:
-            type: string
-            maxLength: 10
-      responses:
-        "204":
-          description: ""
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/problem+json:
-              schema:
-                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-        - Dagelijkse Besturen
-  /dagelijksbestuurlidmaatschappen:
-    get:
-      operationId: getDagelijksBestuurLidmaatschappen
-      description: "Het bericht dat de JSON/REST API voor het ophalen van lidmaatschappen van het dagelijks bestuur retourneert."
-      parameters: 
-        - in: query
-          name: dagelijksbestuuridentificatie
-          description: ""
-          required: true
-          schema:
-            type: string
-            maxLength: 10
-        - in: query
-          name: page
-          description: "Een pagina binnen de gepagineerde resultatenset."
-          required: false
-          schema:
-            type: integer
-            minimum: 1
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-            X-Pagination-Page:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
-            X-Pagination-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
-          content:
-            application/hal+json:
-              schema:
-                type: object
-                properties:
-                  _links:
-                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
-                  _embedded:
-                    type: object
-                    properties:
-                      dagelijksbestuurlidmaatschappen:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/DagelijksBestuurLidmaatschap'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-      - Dagelijksbestuurlidmaatschappen
-    post:
-      operationId: postDagelijksBestuurLidmaatschap
-      description: "Registreer een DagelijksBestuurLidmaatschap."
-      responses:
-        '201':
-          description: ''
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DagelijksBestuurLidmaatschap'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Dagelijksbestuurlidmaatschappen
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DagelijksBestuurLidmaatschap'
-        required: true
-    put:
-      operationId: putDagelijksBestuurLidmaatschap
-      description: "Wijzig een bestaand DagelijksBestuurLidmaatschap"
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/DagelijksBestuurLidmaatschap'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Dagelijksbestuurlidmaatschappen
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DagelijksBestuurLidmaatschap'
-        required: true
-  /fracties/{fractienummer}:
-    get:
-      operationId: getFractie
-      description: "Het bericht dat de JSON/REST API voor het ophalen van fractie gegevens retourneert."
-      parameters: 
-        - in: path
-          name: fractienummer
-          description: "Het nummer dat de FRACTIE uniek identificeert binnen de gemeente viercijferige gemeentecode gevolgd door een volgnummer van 7 cijfers met voorloopnullen"
-          required: true
-          schema:
-            type: string
-            maxLength: 10
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/Fractie'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-      - Fracties
-    delete:
-      operationId: delFractie
-      description: "Het bericht dat de JSON/REST API voor het verwijderen van een FRACTIE. Bij het verwijderen van een FRACTIE is het de rol van de provider om de gerelateerde FRACTIELIDMAATSCHAPPEN en STEMRESULTAATPERFRACTIE ook te verwijderen middels een cascade delete"
-      parameters: 
-        - in: path
-          name: fractienummer
-          description: "Het nummer dat de FRACTIE uniek identificeert binnen de gemeente viercijferige gemeentecode gevolgd door een volgnummer van 6 cijfers met voorloopnullen"
-          required: true
-          schema:
-            type: string
-            maxLength: 10
-      responses:
-        "204":
-          description: ""
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/problem+json:
-              schema:
-                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-        - Fracties
-  /fracties:
-    get:
-      operationId: getFracties
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een collectie fracties retourneert."
-      parameters: 
-        - in: query
-          name: page
-          description: "Een pagina binnen de gepagineerde resultatenset."
-          required: false
-          schema:
-            type: integer
-            minimum: 1
-        - in: query
-          name: fractienaam
-          description: "De naam van de fractie."
-          required: false
-          schema:
-            type: string
-            maxLength: 100
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-            X-Pagination-Page:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
-            X-Pagination-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
-          content:
-            application/hal+json:
-              schema:
-                type: object
-                properties:
-                  _links:
-                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
-                  _embedded:
-                    type: object
-                    properties:
-                      fracties:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Fractie'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-      - Fracties
-    post:
-      operationId: postFractie
-      description: "Registreer een Fractie"
-      responses:
-        '201':
-          description: ''
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Fractie'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Fracties
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Fractie'
-        required: true
-    put:
-      operationId: putFractie
-      description: "Wijzig een bestaande Fractie. Als wijziging (ook) het verwijderen van een FractieLidmaatschap betreft is het de rol van de provider om de betreffende gerelateerde Fractielidmaatschap te verwijderen. "
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/Fractie'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Fracties
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Fractie'
-        required: true
   /fractielidmaatschappen:
     get:
-      operationId: getFractieLidmaatschappen
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een collectie fractielidmaatschappen retourneert."
+      operationId: Getfractielidmaatschappen
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een collectie fractielidmaatschappen retourneert.</p></body>"
       parameters: 
         - in: query
           name: page
@@ -2456,10 +2278,11 @@ paths:
             type: string
         - in: query
           name: datumeindefractielidmaatschap
-          description: "De datum en tijdstip waarop het fractie lidmaatschap geëindigd is."
+          description: "De datum en tijdstip waarop het fractie lidmaatschap geÃ«indigd is."
           required: false
           schema:
             type: string
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
         - in: query
           name: fractielidmaatschapidentificatie
           description: ""
@@ -2478,242 +2301,509 @@ paths:
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Pagination-Page:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
             X-Pagination-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                type: object
-                properties:
-                  _links:
-                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
-                  _embedded:
-                    type: object
-                    properties:
-                      fractielidmaatschappen:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/FractieLidmaatschap'
+                $ref: '#/components/schemas/FractieLidmaatschapHalCollectie'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Fractielidmaatschappen
+  /fractielidmaatschappen/{fractielidmaatschapidentificatie}:
+    delete:
+      operationId: delfractielidmaatschappen
+      description: "<body><p>Het bericht dat de JSON/REST API voor het verwijderen van gegevens van een fractielidmaatschap</p></body>"
+      parameters: 
+        - in: path
+          name: fractielidmaatschapidentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+      responses:
+        '200':
+          description: "Verwijderactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+        '204':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/204"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+      tags: 
+      - Fractielidmaatschappen
+    get:
+      operationId: Getfractielidmaatschap
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een fractielidmaatschappen retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: fractielidmaatschapidentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/FractieLidmaatschapHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
       - Fractielidmaatschappen
     post:
-      operationId: postFractieLidmaatschap
-      description: "Registreer een Fractielidmaatschap"
+      operationId: postfractielidmaatschappenFractielidmaatschapidentificatie
+      description: "<body><p>Het vastleggen van een FRACTIELIDMAATSCHAP</p></body>"
+      parameters: 
+        - in: path
+          name: fractielidmaatschapidentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/FractieLidmaatschapHal'
       responses:
         '201':
-          description: ''
+          description: "OK"
           headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/json:
+            Location:
+              description: "URI van de nieuwe resource"
               schema:
-                $ref: '#/components/schemas/DagelijksBestuur'
+                type: string
+                format: uri
+                example: '/fractielidmaatschappen/{fractielidmaatschapidentificatie}/'
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/FractieLidmaatschapHal'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
-      tags:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
       - Fractielidmaatschappen
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/FractieLidmaatschap'
-        required: true
     put:
-      operationId: putFractieLidmaatschap
-      description: "Wijzig een bestaand Fractielidmaatschap"
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/DagelijksBestuur'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Fractielidmaatschappen
+      operationId: Putfractielidmaatschap
+      description: "<body><p>Het wijzigen van een FRACTIES</p></body>"
+      parameters: 
+        - in: path
+          name: fractielidmaatschapidentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+            maxLength: 10
       requestBody:
         content:
-          application/json:
+          application/hal+json:
             schema:
-              $ref: '#/components/schemas/FractieLidmaatschap'
-        required: true
-  /ingekomenstukken/{informatieobjectidentificatie}:
-    get:
-      operationId: getIngekomenStuk
-      description: "Het bericht dat de JSON/REST API voor het ophalen van ingekomeens stuk-gegevens retourneert."
-      parameters: 
-        - in: path
-          name: informatieobjectidentificatie
-          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
-          required: true
-          schema:
-            type: string
-            maxLength: 40
+                $ref: '#/components/schemas/FractieLidmaatschapHal'
       responses:
         '200':
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/IngekomenStuk'
+                $ref: '#/components/schemas/FractieLidmaatschap'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
-      - Ingekomenstukken
+      - Fractielidmaatschappen
+  /fracties:
+    get:
+      operationId: Getfracties
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een collectie fracties retourneert.</p></body>"
+      parameters: 
+        - in: query
+          name: page
+          description: "Een pagina binnen de gepagineerde resultatenset."
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
+        - in: query
+          name: fractienaam
+          description: "De naam van de fractie."
+          required: false
+          schema:
+            type: string
+            maxLength: 100
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Pagination-Page:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
+            X-Pagination-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/FractieHalCollectie'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Fracties
+  /fracties/{fractienummer}:
     delete:
-      operationId: delIngekomenStuk
-      description: "Het bericht dat de JSON/REST API voor het verwijderen van een Ingekomen Stuk"
+      operationId: delfractie
+      description: "<body><p>Het bericht dat de JSON/REST API voor het verwijderen van gegevens van een fractie.</p></body>"
       parameters: 
         - in: path
-          name: informatieobjectidentificatie
-          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          name: fractienummer
+          description: "Het nummer dat de FRACTIE uniek identificeert binnen de gemeente viercijferige gemeentecode gevolgd door een volgnummer van 7 cijfers met voorloopnullen"
           required: true
           schema:
             type: string
-            maxLength: 40
+            maxLength: 10
       responses:
-        "204":
-          description: ""
+        '200':
+          description: "Verwijderactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/problem+json:
-              schema:
-                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+        '204':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/204"
         '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
       tags: 
-        - Ingekomenstukken
+      - Fracties
+    get:
+      operationId: Getfractie
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van fractie gegevens retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: fractienummer
+          description: "Het nummer dat de FRACTIE uniek identificeert binnen de gemeente viercijferige gemeentecode gevolgd door een volgnummer van 7 cijfers met voorloopnullen"
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/FractieHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Fracties
+    post:
+      operationId: postfractiesFractienummer
+      description: "<body><p>Het vastleggen van een FRACTIE</p></body>"
+      parameters: 
+        - in: path
+          name: fractienummer
+          description: "Het nummer dat de FRACTIE uniek identificeert binnen de gemeente viercijferige gemeentecode gevolgd door een volgnummer van 7 cijfers met voorloopnullen"
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/FractieHal'
+      responses:
+        '201':
+          description: "OK"
+          headers:
+            Location:
+              description: "URI van de nieuwe resource"
+              schema:
+                type: string
+                format: uri
+                example: '/fracties/{fractienummer}/'
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/FractieHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Fracties
+    put:
+      operationId: Putfractie
+      description: "<body><p>Het wijzigen van een FRACTIES</p></body>"
+      parameters: 
+        - in: path
+          name: fractienummer
+          description: "Het nummer dat de FRACTIE uniek identificeert binnen de gemeente viercijferige gemeentecode gevolgd door een volgnummer van 7 cijfers met voorloopnullen"
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/FractieHal'
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/Fractie'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Fracties
   /ingekomenstukken:
     get:
-      operationId: getIngekomenStukken
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een collectie ingekomen stukken retourneert."
+      operationId: Getingekomenstukken
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een collectie ingekomen stukken retourneert.</p></body>"
       parameters: 
         - in: query
           name: page
@@ -2724,42 +2814,36 @@ paths:
             minimum: 1
         - in: query
           name: auteur
-          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creëren van de inhoud van het INFORMATIEOBJECT. Het kan zowel een medewerker of organisatorische eenheid van de zaakbehandelende organisatie betreffen als een externe partij (persoon of organisatie). Het betreft het Dublin Core metadata-element ‘Creator’ met als toelichting: Examples of Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity. Van een ontvangen informatieobject kan de afzender de auteur zijn maar dat kan ook een ander zijn bijvoorbeeld in het geval dat de afzender een document van een derde meestuurt. Indien het informatieobject in een geautomatiseerd proces is vervaardigd, dan wordt als auteur vermeld degene die dat informatieobject ondertekend zou hebben dan wel, bij informatieobjecten waarbij van ondertekening geen sprake is (zoals bijvoorbeeld bij het omzetten van de zaakgegevens naar een duurzaam bewaarbaar informatieobject in pdf), degene die verantwoordelijk is voor de inhoud van het informatieobject vanuit zijn of haar rol bij de zaak (veelal degene in de rol van Zaakcoördinator). De naamgegevens van de auteur zijnde een betrokkene die in een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur niet in een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk persoon of organisatie zijnde de auteur. In het laatste geval verdient het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap wordt uitgeoefend."
+          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creÃ«ren van de inhoud van het INFORMATIEOBJECT. Het kan zowel een medewerker of organisatorische eenheid van de zaakbehandelende organisatie betreffen als een externe partij (persoon of organisatie). Het betreft het Dublin Core metadata-element â€˜Creatorâ€™ met als toelichting: Examples of Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity. Van een ontvangen informatieobject kan de afzender de auteur zijn maar dat kan ook een ander zijn bijvoorbeeld in het geval dat de afzender een document van een derde meestuurt. Indien het informatieobject in een geautomatiseerd proces is vervaardigd, dan wordt als auteur vermeld degene die dat informatieobject ondertekend zou hebben dan wel, bij informatieobjecten waarbij van ondertekening geen sprake is (zoals bijvoorbeeld bij het omzetten van de zaakgegevens naar een duurzaam bewaarbaar informatieobject in pdf), degene die verantwoordelijk is voor de inhoud van het informatieobject vanuit zijn of haar rol bij de zaak (veelal degene in de rol van ZaakcoÃ¶rdinator). De naamgegevens van de auteur zijnde een betrokkene die in een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur niet in een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk persoon of organisatie zijnde de auteur. In het laatste geval verdient het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap wordt uitgeoefend."
           required: false
           schema:
             type: string
             maxLength: 200
         - in: query
           name: creatiedatum
-          description: "creatiedatum creatiedatum Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Deze datum verwijst gewoonlijk naar de creatie van het INFORMATIEOBJECT. Het betreft het Dublin Core metadata-element ‘Date’ met als toelichting: Typically, Date will be associated with the creation or availability of the resource. Recommended best practice for encoding the date value is defined in a profile of ISO 8601 (W3CDTF) and includes (among others) dates of the form YYYY-MM-DD. Alle geldige datums gelegen op of voor de huidige datum en tijd"
+          description: "creatiedatum creatiedatum Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Deze datum verwijst gewoonlijk naar de creatie van het INFORMATIEOBJECT. Het betreft het Dublin Core metadata-element â€˜Dateâ€™ met als toelichting: Typically, Date will be associated with the creation or availability of the resource. Recommended best practice for encoding the date value is defined in a profile of ISO 8601 (W3CDTF) and includes (among others) dates of the form YYYY-MM-DD. Alle geldige datums gelegen op of voor de huidige datum en tijd"
           required: false
           schema:
             type: string
             format: date
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
         - in: query
           name: informatieobjectidentificatie
-          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
           required: false
           schema:
             type: string
             maxLength: 40
         - in: query
-          name: ontvangstdatum
-          description: "ontvangstdatum ontvangstdatum De datum waarop het INFORMATIEOBJECT ontvangen is. De datum waarop het INFORMATIEOBJECT ontvangen is. Het gaat hier om de datum waarop het INFORMATIEOBJECT ontvangen is door de zaakbehandelende organisatie(s), dus niet door een specifieke afdeling of medewerker daarvan. Alle geldige datums gelegen op, voor of na de huidige datum en tijd"
-          required: false
-          schema:
-            type: string
-            format: date
-        - in: query
           name: titel
-          description: "titel titel De naam waaronder het INFORMATIEOBJECT formeel bekend is. De naam waaronder het INFORMATIEOBJECT formeel bekend is. Het betreft het Dublin Core metadata-element ‘Title’ met als toelichting: Typically, Title will be a name by which the resource is formally known. alle alfanumerieke tekens"
+          description: "titel titel De naam waaronder het INFORMATIEOBJECT formeel bekend is. De naam waaronder het INFORMATIEOBJECT formeel bekend is. Het betreft het Dublin Core metadata-element â€˜Titleâ€™ met als toelichting: Typically, Title will be a name by which the resource is formally known. alle alfanumerieke tekens"
           required: false
           schema:
             type: string
             maxLength: 200
         - in: query
           name: versie
-          description: "versie versie Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Het gaat hier om een versienummer zoals ‘0.2’ en 1.0’. Ofschoon we er voor gekozen hebben om zowel dit attribuuttype als het attribuuttype Status optioneel te verklaren, ware het aan te bevelen bij elk documemt in ieder geval één van beide attributen van een waarde te voorzien. Nb: De attribuutsoort is in versie 2.0 verplaatst van ENKELVOUDIG INFORMATIEOBJECT naar INFORMATIEOBJECT. Alle alfanumerieke tekens m.u.v. diacrieten"
+          description: "versie versie Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Het gaat hier om een versienummer zoals â€˜0.2â€™ en 1.0â€™. Ofschoon we er voor gekozen hebben om zowel dit attribuuttype als het attribuuttype Status optioneel te verklaren, ware het aan te bevelen bij elk documemt in ieder geval Ã©Ã©n van beide attributen van een waarde te voorzien. Nb: De attribuutsoort is in versie 2.0 verplaatst van ENKELVOUDIG INFORMATIEOBJECT naar INFORMATIEOBJECT. Alle alfanumerieke tekens m.u.v. diacrieten"
           required: false
           schema:
             type: string
@@ -2769,147 +2853,258 @@ paths:
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Pagination-Page:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
             X-Pagination-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                type: object
-                properties:
-                  _links:
-                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
-                  _embedded:
-                    type: object
-                    properties:
-                      ingekomenstukken:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/IngekomenStuk'
+                $ref: '#/components/schemas/IngekomenStukHalCollectie'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
-      - Ingekomenstukken
-    post:
-      operationId: postIngekomenStuk
-      description: "Registreer een Ingekomen Stuk"
+      - Ingekomen stukken
+  /ingekomenstukken/{informatieobjectidentificatie}:
+    delete:
+      operationId: delingekomenstukken
+      description: "<body><p>Het bericht dat de JSON/REST API voor het verwijderen van gegevens van een ingekomenstuk</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
       responses:
-        '201':
-          description: ''
+        '200':
+          description: "Verwijderactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DagelijksBestuur'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+        '204':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/204"
         '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Ingekomenstukken
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/IngekomenStuk'
-        required: true
-    put:
-      operationId: putIngekomenStuk
-      description: "Wijzig een bestaand IngekomenStuk"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+      tags: 
+      - Ingekomen stukken
+    get:
+      operationId: Getingekomenstuk
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van ingekomen stuk-gegevens retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
       responses:
         '200':
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/DagelijksBestuur'
+                $ref: '#/components/schemas/IngekomenStukHal'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Ingekomenstukken
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Ingekomen stukken
+    post:
+      operationId: postingekomenstukkenInformatieobjectidentificatie
+      description: "<body><p>Het vastleggen van een Ingekomen stuk</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+        - in: query
+          name: fields
+          description: ""
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
-          application/json:
+          application/hal+json:
             schema:
-              $ref: '#/components/schemas/IngekomenStuk'
-        required: true
+                $ref: '#/components/schemas/IngekomenStukHal'
+      responses:
+        '201':
+          description: "OK"
+          headers:
+            Location:
+              description: "URI van de nieuwe resource"
+              schema:
+                type: string
+                format: uri
+                example: '/ingekomenstukken/{informatieobjectidentificatie}/'
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/IngekomenStukHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Ingekomen stukken
+    put:
+      operationId: Putingekomenstuk
+      description: "<body><p>Het wijzigen van een FRACTIES</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+        - in: query
+          name: fields
+          description: ""
+          required: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/IngekomenStukHal'
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/IngekomenStuk'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Ingekomen stukken
   /mededelingen:
     get:
-      operationId: getMededelingen
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een collectie mededelingen retourneert."
+      operationId: Getmededelingen
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een collectie toezeggingen retourneert.</p></body>"
       parameters: 
         - in: query
           name: page
@@ -2920,21 +3115,21 @@ paths:
             minimum: 1
         - in: query
           name: auteur
-          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creëren van de inhoud van het INFORMATIEOBJECT. Het kan zowel een medewerker of organisatorische eenheid van de zaakbehandelende organisatie betreffen als een externe partij (persoon of organisatie). Het betreft het Dublin Core metadata-element ‘Creator’ met als toelichting: Examples of Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity. Van een ontvangen informatieobject kan de afzender de auteur zijn maar dat kan ook een ander zijn bijvoorbeeld in het geval dat de afzender een document van een derde meestuurt. Indien het informatieobject in een geautomatiseerd proces is vervaardigd, dan wordt als auteur vermeld degene die dat informatieobject ondertekend zou hebben dan wel, bij informatieobjecten waarbij van ondertekening geen sprake is (zoals bijvoorbeeld bij het omzetten van de zaakgegevens naar een duurzaam bewaarbaar informatieobject in pdf), degene die verantwoordelijk is voor de inhoud van het informatieobject vanuit zijn of haar rol bij de zaak (veelal degene in de rol van Zaakcoördinator). De naamgegevens van de auteur zijnde een betrokkene die in een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur niet in een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk persoon of organisatie zijnde de auteur. In het laatste geval verdient het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap wordt uitgeoefend."
+          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creÃ«ren van de inhoud van het INFORMATIEOBJECT. Het kan zowel een medewerker of organisatorische eenheid van de zaakbehandelende organisatie betreffen als een externe partij (persoon of organisatie). Het betreft het Dublin Core metadata-element â€˜Creatorâ€™ met als toelichting: Examples of Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity. Van een ontvangen informatieobject kan de afzender de auteur zijn maar dat kan ook een ander zijn bijvoorbeeld in het geval dat de afzender een document van een derde meestuurt. Indien het informatieobject in een geautomatiseerd proces is vervaardigd, dan wordt als auteur vermeld degene die dat informatieobject ondertekend zou hebben dan wel, bij informatieobjecten waarbij van ondertekening geen sprake is (zoals bijvoorbeeld bij het omzetten van de zaakgegevens naar een duurzaam bewaarbaar informatieobject in pdf), degene die verantwoordelijk is voor de inhoud van het informatieobject vanuit zijn of haar rol bij de zaak (veelal degene in de rol van ZaakcoÃ¶rdinator). De naamgegevens van de auteur zijnde een betrokkene die in een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur niet in een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk persoon of organisatie zijnde de auteur. In het laatste geval verdient het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap wordt uitgeoefend."
           required: false
           schema:
             type: string
             maxLength: 200
         - in: query
           name: bronorganisatie
-          description: "bronorganisatie bronorganisatie Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Het betreft het RSIN (Rechtspersonen en Samenwerkingsverbanden InformatieNummer) zoals dat door de KvK in het NHR aan elk rechtspersoon en samenwerkingsverband is toegekend. Dit identificeert uniek de organisatie, zijnde een rechtspersoon of samenwerkingsverband, dat het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Met het laatste doelen we er op dat bij uitwisseling van een informatieobject tussen samenwerkende organisaties de unieke aanduiding van het informatieobject niet wijzigt mits de ontvangende organisatie geen wijzigingen in het informatieobject aanbrengt. In het laatste geval ontstaat een nieuw informatieobject. Het RSIN staat in het Handelsregister (NHR) en op het daaraan te ontlenen uittreksel. Deze attribuutsoort vormt tezamen met de Informatieobjectidentificatie de unieke aanduiding van een informatieobject voor geheel Nederland. De waarde van dit attribuutsoort wijzigt niet, ook niet indien (de behandeling van) het informatieobject over zou gaan naar een andere organisatie. Er is immers maar één organisatie die het informatieobject gecreëerd of als eerste vastgelegd heeft. De in het NHR voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden."
+          description: "bronorganisatie bronorganisatie Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Het betreft het RSIN (Rechtspersonen en Samenwerkingsverbanden InformatieNummer) zoals dat door de KvK in het NHR aan elk rechtspersoon en samenwerkingsverband is toegekend. Dit identificeert uniek de organisatie, zijnde een rechtspersoon of samenwerkingsverband, dat het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Met het laatste doelen we er op dat bij uitwisseling van een informatieobject tussen samenwerkende organisaties de unieke aanduiding van het informatieobject niet wijzigt mits de ontvangende organisatie geen wijzigingen in het informatieobject aanbrengt. In het laatste geval ontstaat een nieuw informatieobject. Het RSIN staat in het Handelsregister (NHR) en op het daaraan te ontlenen uittreksel. Deze attribuutsoort vormt tezamen met de Informatieobjectidentificatie de unieke aanduiding van een informatieobject voor geheel Nederland. De waarde van dit attribuutsoort wijzigt niet, ook niet indien (de behandeling van) het informatieobject over zou gaan naar een andere organisatie. Er is immers maar Ã©Ã©n organisatie die het informatieobject gecreÃ«erd of als eerste vastgelegd heeft. De in het NHR voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden."
           required: false
           schema:
             type: integer
             maximum: 9.99999999E8
         - in: query
           name: creatiedatum
-          description: "creatiedatum creatiedatum Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Deze datum verwijst gewoonlijk naar de creatie van het INFORMATIEOBJECT. Het betreft het Dublin Core metadata-element ‘Date’ met als toelichting: Typically, Date will be associated with the creation or availability of the resource. Recommended best practice for encoding the date value is defined in a profile of ISO 8601 (W3CDTF) and includes (among others) dates of the form YYYY-MM-DD. Alle geldige datums gelegen op of voor de huidige datum en tijd"
+          description: "creatiedatum creatiedatum Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Deze datum verwijst gewoonlijk naar de creatie van het INFORMATIEOBJECT. Het betreft het Dublin Core metadata-element â€˜Dateâ€™ met als toelichting: Typically, Date will be associated with the creation or availability of the resource. Recommended best practice for encoding the date value is defined in a profile of ISO 8601 (W3CDTF) and includes (among others) dates of the form YYYY-MM-DD. Alle geldige datums gelegen op of voor de huidige datum en tijd"
           required: false
           schema:
             type: string
@@ -2946,9 +3141,10 @@ paths:
           schema:
             type: string
             format: date
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
         - in: query
           name: informatieobjectidentificatie
-          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
           required: false
           schema:
             type: string
@@ -2958,7 +3154,7 @@ paths:
           description: "de classificatie van de MOTIE"
           required: false
           schema:
-              $ref: "#/components/schemas/MotieType"
+            $ref: "#/components/schemas/MotieType"
         - in: query
           name: omschrijving
           description: "De omschrijving van het BESLUITVORMINGSSTUK Dit kan de omschrijving zijn van de MOTIE, het AMENDEMENT of het VOORSTEL"
@@ -2970,333 +3166,247 @@ paths:
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Pagination-Page:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
             X-Pagination-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                type: object
-                properties:
-                  _links:
-                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
-                  _embedded:
-                    type: object
-                    properties:
-                      mededelingen:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Mededeling'
+                $ref: '#/components/schemas/MededelingHalCollectie'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Mededelingen
+  /mededelingen/{informatieobjectidentificatie}:
+    delete:
+      operationId: delmededeling
+      description: "<body><p>Het bericht dat de JSON/REST API voor het verwijderen van gegevens van een mededeling.</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+      responses:
+        '200':
+          description: "Verwijderactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+        '204':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/204"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+      tags: 
+      - Mededelingen
+    get:
+      operationId: Getmededeling
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van mededeling gegevens retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/MededelingHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
       - Mededelingen
     post:
-      operationId: postMededeling
-      description: "Registreer een Mededeling"
+      operationId: postmededeling
+      description: "<body><p>Het vastleggen van een FRACTIE</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/MededelingHal'
       responses:
         '201':
-          description: ''
+          description: "OK"
           headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/json:
+            Location:
+              description: "URI van de nieuwe resource"
               schema:
-                $ref: '#/components/schemas/Mededeling'
+                type: string
+                format: uri
+                example: '/mededelingen/{informatieobjectidentificatie}/'
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/MededelingHal'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
-      tags:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
       - Mededelingen
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Mededeling'
-        required: true
     put:
-      operationId: putMededeling
-      description: "Wijzig een bestaand Mededeling"
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/Mededeling'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Mededelingen
+      operationId: Putmededeling
+      description: "<body><p>Het wijzigen van een MEDEDELINGEN</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
       requestBody:
         content:
-          application/json:
+          application/hal+json:
             schema:
-              $ref: '#/components/schemas/Mededeling'
-        required: true
-  /mededelingen/{informatieobjectidentificatie}:
-    get:
-      operationId: getMededeling
-      description: "Het bericht dat de JSON/REST API voor het ophalen van mededeling gegevens retourneert."
-      parameters: 
-        - in: path
-          name: informatieobjectidentificatie
-          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
-          required: true
-          schema:
-            type: string
-            maxLength: 40
+                $ref: '#/components/schemas/MededelingHal'
       responses:
         '200':
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/Mededeling'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
       - Mededelingen
-    delete:
-      operationId: delMededeling
-      description: "Het bericht dat de JSON/REST API voor het verwijderen van een Mededeling"
-      parameters: 
-        - in: path
-          name: informatieobjectidentificatie
-          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
-          required: true
-          schema:
-            type: string
-            maxLength: 40
-      responses:
-        "204":
-          description: ""
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/problem+json:
-              schema:
-                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-        - Mededelingen
-  /moties/{informatieobjectidentificatie}:
-    get:
-      operationId: getMotie
-      description: "Het bericht dat de JSON/REST API voor het ophalen van motie gegevens retourneert."
-      parameters: 
-        - in: path
-          name: informatieobjectidentificatie
-          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
-          required: true
-          schema:
-            type: string
-            maxLength: 40
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/Motie'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-      - Moties
-    delete:
-      operationId: delMotie
-      description: "Het bericht dat de JSON/REST API voor het verwijderen van een Motie"
-      parameters: 
-        - in: path
-          name: informatieobjectidentificatie
-          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
-          required: true
-          schema:
-            type: string
-            maxLength: 40
-      responses:
-        "204":
-          description: ""
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/problem+json:
-              schema:
-                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-        - Moties
   /moties:
     get:
-      operationId: getMoties
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een collectie moties retourneert."
+      operationId: Getmoties
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een collectie moties retourneert.</p></body>"
       parameters: 
         - in: query
           name: page
@@ -3307,21 +3417,21 @@ paths:
             minimum: 1
         - in: query
           name: auteur
-          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creëren van de inhoud van het INFORMATIEOBJECT. Het kan zowel een medewerker of organisatorische eenheid van de zaakbehandelende organisatie betreffen als een externe partij (persoon of organisatie). Het betreft het Dublin Core metadata-element ‘Creator’ met als toelichting: Examples of Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity. Van een ontvangen informatieobject kan de afzender de auteur zijn maar dat kan ook een ander zijn bijvoorbeeld in het geval dat de afzender een document van een derde meestuurt. Indien het informatieobject in een geautomatiseerd proces is vervaardigd, dan wordt als auteur vermeld degene die dat informatieobject ondertekend zou hebben dan wel, bij informatieobjecten waarbij van ondertekening geen sprake is (zoals bijvoorbeeld bij het omzetten van de zaakgegevens naar een duurzaam bewaarbaar informatieobject in pdf), degene die verantwoordelijk is voor de inhoud van het informatieobject vanuit zijn of haar rol bij de zaak (veelal degene in de rol van Zaakcoördinator). De naamgegevens van de auteur zijnde een betrokkene die in een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur niet in een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk persoon of organisatie zijnde de auteur. In het laatste geval verdient het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap wordt uitgeoefend."
+          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creÃ«ren van de inhoud van het INFORMATIEOBJECT. Het kan zowel een medewerker of organisatorische eenheid van de zaakbehandelende organisatie betreffen als een externe partij (persoon of organisatie). Het betreft het Dublin Core metadata-element â€˜Creatorâ€™ met als toelichting: Examples of Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity. Van een ontvangen informatieobject kan de afzender de auteur zijn maar dat kan ook een ander zijn bijvoorbeeld in het geval dat de afzender een document van een derde meestuurt. Indien het informatieobject in een geautomatiseerd proces is vervaardigd, dan wordt als auteur vermeld degene die dat informatieobject ondertekend zou hebben dan wel, bij informatieobjecten waarbij van ondertekening geen sprake is (zoals bijvoorbeeld bij het omzetten van de zaakgegevens naar een duurzaam bewaarbaar informatieobject in pdf), degene die verantwoordelijk is voor de inhoud van het informatieobject vanuit zijn of haar rol bij de zaak (veelal degene in de rol van ZaakcoÃ¶rdinator). De naamgegevens van de auteur zijnde een betrokkene die in een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur niet in een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk persoon of organisatie zijnde de auteur. In het laatste geval verdient het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap wordt uitgeoefend."
           required: false
           schema:
             type: string
             maxLength: 200
         - in: query
           name: bronorganisatie
-          description: "bronorganisatie bronorganisatie Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Het betreft het RSIN (Rechtspersonen en Samenwerkingsverbanden InformatieNummer) zoals dat door de KvK in het NHR aan elk rechtspersoon en samenwerkingsverband is toegekend. Dit identificeert uniek de organisatie, zijnde een rechtspersoon of samenwerkingsverband, dat het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Met het laatste doelen we er op dat bij uitwisseling van een informatieobject tussen samenwerkende organisaties de unieke aanduiding van het informatieobject niet wijzigt mits de ontvangende organisatie geen wijzigingen in het informatieobject aanbrengt. In het laatste geval ontstaat een nieuw informatieobject. Het RSIN staat in het Handelsregister (NHR) en op het daaraan te ontlenen uittreksel. Deze attribuutsoort vormt tezamen met de Informatieobjectidentificatie de unieke aanduiding van een informatieobject voor geheel Nederland. De waarde van dit attribuutsoort wijzigt niet, ook niet indien (de behandeling van) het informatieobject over zou gaan naar een andere organisatie. Er is immers maar één organisatie die het informatieobject gecreëerd of als eerste vastgelegd heeft. De in het NHR voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden."
+          description: "bronorganisatie bronorganisatie Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Het betreft het RSIN (Rechtspersonen en Samenwerkingsverbanden InformatieNummer) zoals dat door de KvK in het NHR aan elk rechtspersoon en samenwerkingsverband is toegekend. Dit identificeert uniek de organisatie, zijnde een rechtspersoon of samenwerkingsverband, dat het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Met het laatste doelen we er op dat bij uitwisseling van een informatieobject tussen samenwerkende organisaties de unieke aanduiding van het informatieobject niet wijzigt mits de ontvangende organisatie geen wijzigingen in het informatieobject aanbrengt. In het laatste geval ontstaat een nieuw informatieobject. Het RSIN staat in het Handelsregister (NHR) en op het daaraan te ontlenen uittreksel. Deze attribuutsoort vormt tezamen met de Informatieobjectidentificatie de unieke aanduiding van een informatieobject voor geheel Nederland. De waarde van dit attribuutsoort wijzigt niet, ook niet indien (de behandeling van) het informatieobject over zou gaan naar een andere organisatie. Er is immers maar Ã©Ã©n organisatie die het informatieobject gecreÃ«erd of als eerste vastgelegd heeft. De in het NHR voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden."
           required: false
           schema:
             type: integer
             maximum: 9.99999999E8
         - in: query
           name: creatiedatum
-          description: "creatiedatum creatiedatum Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Deze datum verwijst gewoonlijk naar de creatie van het INFORMATIEOBJECT. Het betreft het Dublin Core metadata-element ‘Date’ met als toelichting: Typically, Date will be associated with the creation or availability of the resource. Recommended best practice for encoding the date value is defined in a profile of ISO 8601 (W3CDTF) and includes (among others) dates of the form YYYY-MM-DD. Alle geldige datums gelegen op of voor de huidige datum en tijd"
+          description: "creatiedatum creatiedatum Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Deze datum verwijst gewoonlijk naar de creatie van het INFORMATIEOBJECT. Het betreft het Dublin Core metadata-element â€˜Dateâ€™ met als toelichting: Typically, Date will be associated with the creation or availability of the resource. Recommended best practice for encoding the date value is defined in a profile of ISO 8601 (W3CDTF) and includes (among others) dates of the form YYYY-MM-DD. Alle geldige datums gelegen op of voor de huidige datum en tijd"
           required: false
           schema:
             type: string
@@ -3333,9 +3443,10 @@ paths:
           schema:
             type: string
             format: date
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
         - in: query
           name: informatieobjectidentificatie
-          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
           required: false
           schema:
             type: string
@@ -3345,7 +3456,7 @@ paths:
           description: "de classificatie van de MOTIE"
           required: false
           schema:
-              $ref: "#/components/schemas/MotieType"
+            $ref: "#/components/schemas/MotieType"
         - in: query
           name: omschrijving
           description: "De omschrijving van het BESLUITVORMINGSSTUK Dit kan de omschrijving zijn van de MOTIE, het AMENDEMENT of het VOORSTEL"
@@ -3357,238 +3468,247 @@ paths:
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Pagination-Page:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
             X-Pagination-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                type: object
-                properties:
-                  _links:
-                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
-                  _embedded:
-                    type: object
-                    properties:
-                      Moties:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Motie'
+                $ref: '#/components/schemas/MotieHalCollectie'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Moties
+  /moties/{informatieobjectidentificatie}:
+    delete:
+      operationId: delmotie
+      description: "<body><p>Het bericht dat de JSON/REST API voor het verwijderen van gegevens van een motie.</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+      responses:
+        '200':
+          description: "Verwijderactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+        '204':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/204"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+      tags: 
+      - Moties
+    get:
+      operationId: Getmotie
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van motie gegevens retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/MotieHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
       - Moties
     post:
-      operationId: postMotie
-      description: "Registreer een Motie"
+      operationId: postmotie
+      description: "<body><p>Het vastleggen van een FRACTIE</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/MotieHal'
       responses:
         '201':
-          description: ''
+          description: "OK"
           headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/json:
+            Location:
+              description: "URI van de nieuwe resource"
               schema:
-                $ref: '#/components/schemas/Motie'
+                type: string
+                format: uri
+                example: '/moties/{informatieobjectidentificatie}/'
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/MotieHal'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
-      tags:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
       - Moties
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Motie'
-        required: true
     put:
-      operationId: putMotie
-      description: "Wijzig een bestaand Motie"
+      operationId: Putmotie
+      description: "<body><p>Het wijzigen van een MEDEDELINGEN</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/MotieHal'
       responses:
         '200':
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/Motie'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
-      tags:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
       - Moties
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Motie'
-        required: true
-  /natuurlijkpersonen/{nummernatuurlijkpersoon}:
-    get:
-      operationId: getNatuurlijkPersoon
-      description: "Het bericht dat de JSON/REST API voor het ophalen van persoonsgegevens retourneert."
-      parameters: 
-        - in: path
-          name: nummernatuurlijkpersoon
-          description: "Het identificerende nummer van een NATUURLIJK PERSOON niet zijnde het burgerservicenummer Het kan dus voorkomen dat dezelfde natuurlijke persoon bij twee of meer gemeenten geregistreerd is onder een ander nummer. viercijferige gemeentecode gevolgd door een volgnummer van 13 cijfers met voorloopnullen"
-          required: true
-          schema:
-            type: string
-            maxLength: 17
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/NatuurlijkPersoon'
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-      - Natuurlijkpersonen
-    delete:
-      operationId: delNatuurlijkPersoon
-      description: "Het bericht dat de JSON/REST API voor het verwijderen van een NATUURLIJKPERSOON. Bij het verwijderen van een DAGELIJKSBESTUUR is het de taak van de provider de gerelateerde DaAGELIJKSBESTUURLIDMAATSCHAPen te verwijderen middels om een cascade-delete. "
-      parameters: 
-        - in: path
-          name: nummernatuurlijkpersoon
-          description: "Het identificerende nummer van een NATUURLIJK PERSOON niet zijnde het burgerservicenummer Het kan dus voorkomen dat dezelfde natuurlijke persoon bij twee of meer gemeenten geregistreerd is onder een ander nummer. viercijferige gemeentecode gevolgd door een volgnummer van 13 cijfers met voorloopnullen"
-          required: true
-          schema:
-            type: string
-            maxLength: 17
-      responses:
-        "204":
-          description: ""
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/problem+json:
-              schema:
-                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-        - Natuurlijkpersonen
   /natuurlijkpersonen:
     get:
-      operationId: getNatuurlijkPersonen
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een collectie personen retourneert."
+      operationId: GetnatuurlijkPersonen
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een collectie personen retourneert.</p></body>"
       parameters: 
         - in: query
           name: page
@@ -3604,18 +3724,19 @@ paths:
           schema:
             type: string
             maxLength: 200
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
         - in: query
           name: functie
           description: "De functie van een persoon"
           required: false
           schema:
-              $ref: "#/components/schemas/Functie"
+            $ref: "#/components/schemas/Functie"
         - in: query
           name: geslachtsaanduiding
           description: "Een aanduiding die aangeeft dat de persoon een man, een vrouw, anders of dat het geslacht (nog) onbekend is."
           required: false
           schema:
-              $ref: "#/components/schemas/Geslacht"
+            $ref: "#/components/schemas/Geslacht"
         - in: query
           name: nummernatuurlijkpersoon
           description: "Het identificerende nummer van een NATUURLIJK PERSOON niet zijnde het burgerservicenummer Het kan dus voorkomen dat dezelfde natuurlijke persoon bij twee of meer gemeenten geregistreerd is onder een ander nummer. viercijferige gemeentecode gevolgd door een volgnummer van 13 cijfers met voorloopnullen"
@@ -3628,143 +3749,247 @@ paths:
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Pagination-Page:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
             X-Pagination-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                type: object
-                properties:
-                  _links:
-                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
-                  _embedded:
-                    type: object
-                    properties:
-                      natuurlijkpersonen:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/NatuurlijkPersoon'
+                $ref: '#/components/schemas/NatuurlijkPersoonHalCollectie'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
       - Natuurlijkpersonen
-    post:
-      operationId: postNatuurlijkPersoon
-      description: "Registreer een NatuurlijkPersoon"
+  /natuurlijkpersonen/{nummernatuurlijkpersoon}:
+    delete:
+      operationId: delnatuurlijkpersoon
+      description: "<body><p>Het bericht dat de JSON/REST API voor het verwijderen van gegevens van een persoon.</p></body>"
+      parameters: 
+        - in: path
+          name: nummernatuurlijkpersoon
+          description: "Het identificerende nummer van een NATUURLIJK PERSOON niet zijnde het burgerservicenummer Het kan dus voorkomen dat dezelfde natuurlijke persoon bij twee of meer gemeenten geregistreerd is onder een ander nummer. viercijferige gemeentecode gevolgd door een volgnummer van 13 cijfers met voorloopnullen"
+          required: true
+          schema:
+            type: string
+            maxLength: 17
       responses:
-        '201':
-          description: ''
+        '200':
+          description: "Verwijderactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NatuurlijkPersoon'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+        '204':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/204"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+      tags: 
       - Natuurlijkpersonen
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/NatuurlijkPersoon'
-        required: true
-    put:
-      operationId: putNatuurlijkPersoon
-      description: "Wijzig een bestaand NatuurlijkPersoon"
+    get:
+      operationId: GetnatuurlijkPersoon
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van persoonsgegevens retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: nummernatuurlijkpersoon
+          description: "Het identificerende nummer van een NATUURLIJK PERSOON niet zijnde het burgerservicenummer Het kan dus voorkomen dat dezelfde natuurlijke persoon bij twee of meer gemeenten geregistreerd is onder een ander nummer. viercijferige gemeentecode gevolgd door een volgnummer van 13 cijfers met voorloopnullen"
+          required: true
+          schema:
+            type: string
+            maxLength: 17
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
       responses:
         '200':
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/Motie'
+                $ref: '#/components/schemas/NatuurlijkPersoonHal'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
-      tags:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
       - Natuurlijkpersonen
+    post:
+      operationId: postnatuurlijkpersoon
+      description: "<body><p>Het vastleggen van een Persoon</p></body>"
+      parameters: 
+        - in: path
+          name: nummernatuurlijkpersoon
+          description: "Het identificerende nummer van een NATUURLIJK PERSOON niet zijnde het burgerservicenummer Het kan dus voorkomen dat dezelfde natuurlijke persoon bij twee of meer gemeenten geregistreerd is onder een ander nummer. viercijferige gemeentecode gevolgd door een volgnummer van 13 cijfers met voorloopnullen"
+          required: true
+          schema:
+            type: string
+            maxLength: 17
       requestBody:
         content:
-          application/json:
+          application/hal+json:
             schema:
-              $ref: '#/components/schemas/NatuurlijkPersoon'
-        required: true
+                $ref: '#/components/schemas/NatuurlijkPersoonHal'
+      responses:
+        '201':
+          description: "OK"
+          headers:
+            Location:
+              description: "URI van de nieuwe resource"
+              schema:
+                type: string
+                format: uri
+                example: '/natuurlijkpersonen/{nummernatuurlijkpersoon}/'
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/NatuurlijkPersoonHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Natuurlijkpersonen
+    put:
+      operationId: Putnatuurlijkpersoon
+      description: "<body><p>Het wijzigen van een MEDEDELINGEN</p></body>"
+      parameters: 
+        - in: path
+          name: nummernatuurlijkpersoon
+          description: "Het identificerende nummer van een NATUURLIJK PERSOON niet zijnde het burgerservicenummer Het kan dus voorkomen dat dezelfde natuurlijke persoon bij twee of meer gemeenten geregistreerd is onder een ander nummer. viercijferige gemeentecode gevolgd door een volgnummer van 13 cijfers met voorloopnullen"
+          required: true
+          schema:
+            type: string
+            maxLength: 17
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/NatuurlijkPersoonHal'
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/NatuurlijkPersoon'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Natuurlijkpersonen
   /spreekfragmenten:
     get:
-      operationId: getSpreekfragmenten
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een spreekfragment retourneert."
+      operationId: Getspreekfragmenten
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een spreekfragment retourneert.</p></body>"
       parameters: 
         - in: query
           name: page
@@ -3793,6 +4018,7 @@ paths:
           schema:
             type: integer
             maximum: 999999
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
         - in: query
           name: positienotulen
           description: "De positie van het SPREEKFRAGMENT binnen de notulen"
@@ -3839,236 +4065,243 @@ paths:
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Pagination-Page:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
             X-Pagination-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                type: object
-                properties:
-                  _links:
-                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
-                  _embedded:
-                    type: object
-                    properties:
-                      spreekfragmenten:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Spreekfragment'
+                $ref: '#/components/schemas/SpreekfragmentHalCollectie'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Spreekfragmenten
+  /spreekfragmenten/{spreekfragmentidentificatie}:
+    delete:
+      operationId: delspreekfragment
+      description: "<body><p>Het bericht dat de JSON/REST API voor het verwijderen van gegevens van een spreekfragment.</p></body>"
+      parameters: 
+        - in: path
+          name: spreekfragmentidentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: "Verwijderactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+        '204':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/204"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+      tags: 
+      - Spreekfragmenten
+    get:
+      operationId: Getspreekfragment
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een spreekfragment retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: spreekfragmentidentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/SpreekfragmentHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
       - Spreekfragmenten
     post:
-      operationId: postSpreekfragment
-      description: "Registreer een Spreekfragment"
+      operationId: postspreekfragment
+      description: "<body><p>Het vastleggen van een Spreekfragment</p></body>"
+      parameters: 
+        - in: path
+          name: spreekfragmentidentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/SpreekfragmentHal'
       responses:
         '201':
-          description: ''
+          description: "OK"
           headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/json:
+            Location:
+              description: "URI van de nieuwe resource"
               schema:
-                $ref: '#/components/schemas/Spreekfragment'
+                type: string
+                format: uri
+                example: '/spreekfragmenten/{spreekfragmentidentificatie}/'
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/SpreekfragmentHal'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
-      tags:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
       - Spreekfragmenten
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Spreekfragment'
-        required: true
     put:
-      operationId: putSpreekfragment
-      description: "Wijzig een bestaand Spreekfragment"
+      operationId: Putspreekfragment
+      description: "<body><p>Het wijzigen van een spreekfragment</p></body>"
+      parameters: 
+        - in: path
+          name: spreekfragmentidentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/SpreekfragmentHal'
       responses:
         '200':
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/Spreekfragment'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Spreekfragmenten
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Spreekfragment'
-        required: true
-  /spreekfragmenten/{spreekfragmentidentificatie}:
-    get:
-      operationId: getSpreekfragment
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een spreekfragment retourneert."
-      parameters: 
-        - in: path
-          name: spreekfragmentidentificatie
-          description: ""
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/Spreekfragment'
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
       - Spreekfragmenten
-    delete:
-      operationId: delSpreekfragment
-      description: "Het bericht dat de JSON/REST API voor het verwijderen van een Spreekfragment"
-      parameters: 
-        - in: path
-          name: spreekfragmentidentificatie
-          description: ""
-          required: true
-          schema:
-            type: string
-      responses:
-        "204":
-          description: ""
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/problem+json:
-              schema:
-                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-        - Spreekfragmenten
   /stemmen:
     get:
-      operationId: getStemmen
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een spreekfragment retourneert."
+      operationId: Getstemmen
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een spreekfragment retourneert.</p></body>"
       parameters: 
         - in: query
           name: page
@@ -4077,154 +4310,520 @@ paths:
           schema:
             type: integer
             minimum: 1
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
         - in: query
           name: keuzemondelingestemming
           description: "De uitgebrachte keuze van een STEM Het gaat hierbij om een uitgebrachte stem van een STEMMING die niet over een persoon gaat. Die worden namelijk niet vastgelegd per uitgebrachte STEM."
           required: false
           schema:
-              $ref: "#/components/schemas/StemKeuze"
+            $ref: "#/components/schemas/StemKeuze"
       responses:
         '200':
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Pagination-Page:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
             X-Pagination-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                type: object
-                properties:
-                  _links:
-                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
-                  _embedded:
-                    type: object
-                    properties:
-                      stemmen:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Stem'
+                $ref: '#/components/schemas/StemHalCollectie'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Stemmen
+  /stemmen/{stemidentificatie}:
+    delete:
+      operationId: delstem
+      description: "<body><p>Het bericht dat de JSON/REST API voor het verwijderen van gegevens van een stem.</p></body>"
+      parameters: 
+        - in: path
+          name: stemidentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+      responses:
+        '200':
+          description: "Verwijderactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+        '204':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/204"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+      tags: 
+      - Stemmen
+    get:
+      operationId: Getstem
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een spreekfragment retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: stemidentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/StemHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
       - Stemmen
     post:
-      operationId: postStem
-      description: "Registreer een Stem"
-      responses:
-        '201':
-          description: ''
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Stem'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Stemmen
+      operationId: poststem
+      description: "<body><p>Het vastleggen van een Stem</p></body>"
+      parameters: 
+        - in: path
+          name: stemidentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+            maxLength: 10
       requestBody:
         content:
-          application/json:
+          application/hal+json:
             schema:
-              $ref: '#/components/schemas/Stem'
-        required: true
+                $ref: '#/components/schemas/StemHal'
+      responses:
+        '201':
+          description: "OK"
+          headers:
+            Location:
+              description: "URI van de nieuwe resource"
+              schema:
+                type: string
+                format: uri
+                example: '/stemmen/{stemIdentificatie}/'
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/StemHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Stemmen
     put:
-      operationId: putStem
-      description: "Wijzig een bestaand Stem"
+      operationId: Putstem
+      description: "<body><p>Het wijzigen van een stem</p></body>"
+      parameters: 
+        - in: path
+          name: stemidentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/StemHal'
       responses:
         '200':
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/Stem'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
-      tags:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
       - Stemmen
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Stem'
-        required: true
   /stemmingen:
     get:
-      operationId: getStemmingen
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een collectie stemmingen retourneert."
+      operationId: Getstemmingen
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een collectie stemmingen retourneert.</p></body>"
+      parameters: 
+        - in: query
+          name: page
+          description: "Een pagina binnen de gepagineerde resultatenset."
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
+        - in: query
+          name: stemmingstype
+          description: "De wijze waarop de STEMMING is gehouden De wijze waarop de STEMMING is gehouden"
+          required: false
+          schema:
+            $ref: "#/components/schemas/StemmingsType"
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Pagination-Page:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
+            X-Pagination-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/StemmingHalCollectie'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Stemmingen
+  /stemmingen/{stemmingsidentificatie}:
+    delete:
+      operationId: delstemming
+      description: "<body><p>Het bericht dat de JSON/REST API voor het verwijderen van gegevens van een stemming</p></body>"
+      parameters: 
+        - in: path
+          name: stemmingsidentificatie
+          description: "De identificatie van de STEMMING De eerste vier karakter zijn de gemeentecode, gevolgd door een volgnummer van 7 cijfers met voorloopnullen"
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+      responses:
+        '200':
+          description: "Verwijderactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+        '204':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/204"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+      tags: 
+      - Stemmingen
+    get:
+      operationId: Getstemming
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van fractie gegevens retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: stemmingsidentificatie
+          description: "De identificatie van de STEMMING De eerste vier karakter zijn de gemeentecode, gevolgd door een volgnummer van 7 cijfers met voorloopnullen"
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/StemmingHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Stemmingen
+    post:
+      operationId: poststemming
+      description: "<body><p>Het vastleggen van een Stemming</p></body>"
+      parameters: 
+        - in: path
+          name: stemmingsidentificatie
+          description: "De identificatie van de STEMMING De eerste vier karakter zijn de gemeentecode, gevolgd door een volgnummer van 7 cijfers met voorloopnullen"
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/StemmingHal'
+      responses:
+        '201':
+          description: "OK"
+          headers:
+            Location:
+              description: "URI van de nieuwe resource"
+              schema:
+                type: string
+                format: uri
+                example: '/stemmingen/{stemmingsidentificatie}/'
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/StemmingHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Stemmingen
+    put:
+      operationId: Putstemming
+      description: "<body><p>Het wijzigen van een stem</p></body>"
+      parameters: 
+        - in: path
+          name: stemmingsidentificatie
+          description: "De identificatie van de STEMMING De eerste vier karakter zijn de gemeentecode, gevolgd door een volgnummer van 7 cijfers met voorloopnullen"
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/StemmingHal'
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/Stemming'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Stemmingen
+  /stemresultatenperfractie:
+    get:
+      operationId: Getstemresultatenperfractie
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een collectie stemresultatenperfractie retourneert.</p></body>"
       parameters: 
         - in: query
           name: page
@@ -4234,253 +4833,15 @@ paths:
             type: integer
             minimum: 1
         - in: query
-          name: stemmingstype
-          description: "De wijze waarop de STEMMING is gehouden De wijze waarop de STEMMING is gehouden"
+          name: fractiestemresultaat
+          description: "Het resultaat van de STEMMING per FRACTIE Wordt afgeleid van de STEMmen uitgebracht bij de STEMMING door de AANWEZIGE DEELNEMERs, behorend bij dezelfde FRACTIE"
           required: false
           schema:
-              $ref: "#/components/schemas/StemmingsType"
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-            X-Pagination-Page:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
-            X-Pagination-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
-          content:
-            application/hal+json:
-              schema:
-                type: object
-                properties:
-                  _links:
-                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
-                  _embedded:
-                    type: object
-                    properties:
-                      stemmingen:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/StemresultaatPerFractie'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-      - Stemmingen
-    post:
-      operationId: postStemming
-      description: "Registreer een Stemming"
-      responses:
-        '201':
-          description: ''
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Stemming'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Stemmingen
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Stemming'
-        required: true
-    put:
-      operationId: putStemming
-      description: "Wijzig een bestaand Stemming"
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/Stemming'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Stemmingen
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Stemming'
-        required: true
-  /stemmingen/{stemmingsidentificatie}:
-    get:
-      operationId: getStemming
-      description: "Het bericht dat de JSON/REST API voor het ophalen van fractie gegevens retourneert."
-      parameters: 
-        - in: path
-          name: stemmingsidentificatie
-          description: "De identificatie van de STEMMING De eerste vier karakter zijn de gemeentecode, gevolgd door een volgnummer van 7 cijfers met voorloopnullen"
-          required: true
-          schema:
-            type: string
-            maxLength: 10
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/Stemming'
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-      - Stemmingen
-    delete:
-      operationId: delStemming
-      description: "Het bericht dat de JSON/REST API voor het verwijderen van een STEMMING. Bij het verwijderen van een STEMMING is het de taak van de provider om gerelateerde STEMen enSTEMRESULTAATPERFRACTIEs te verwijderen middels een cascade-delete."
-      parameters: 
-        - in: path
-          name: stemmingsidentificatie
-          description: "De identificatie van de STEMMING De eerste vier karakter zijn de gemeentecode, gevolgd door een volgnummer van 7 cijfers met voorloopnullen"
-          required: true
-          schema:
-            type: string
-            maxLength: 10
-      responses:
-        "204":
+            $ref: "#/components/schemas/FractieStemResultaat"
+        - in: query
+          name: stemresultaatperfractieidentificatie
           description: ""
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/problem+json:
-              schema:
-                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-        - Stemmingen
-  /stemresultatenperfractie:
-    get:
-      operationId: getStemResultatenPerFractie
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een collectie stemresultatenperfractie retourneert."
-      parameters: 
-        - in: path
-          name: stemmingsidentificatie
-          description: "De identificatie van de STEMMING De eerste vier karakter zijn de gemeentecode, gevolgd door een volgnummer van 7 cijfers met voorloopnullen"
-          required: true
+          required: false
           schema:
             type: string
             maxLength: 10
@@ -4489,238 +4850,259 @@ paths:
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Pagination-Page:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
             X-Pagination-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                type: object
-                properties:
-                  _links:
-                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
-                  _embedded:
-                    type: object
-                    properties:
-                      stemresultatenperfractie:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/StemresultaatPerFractie'
+                $ref: '#/components/schemas/StemresultaatPerFractieHalCollectie'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Stemresultatenperfractie
+  /stemresultatenperfractie/{stemresultaatperfractieidentificatie}:
+    delete:
+      operationId: delstemresultaatperfractie
+      description: "<body><p>Het bericht dat de JSON/REST API voor het verwijderen van gegevens van een stemresultaatPerFractie</p></body>"
+      parameters: 
+        - in: path
+          name: stemresultaatperfractieidentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+      responses:
+        '200':
+          description: "Verwijderactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+        '204':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/204"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+      tags: 
+      - Stemresultaten per fractie
+    get:
+      operationId: Getstemresultaatperfractie
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een collectie stemresultatenperfractie retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: stemresultaatperfractieidentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/StemresultaatPerFractieHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
       - Stemresultatenperfractie
     post:
-      operationId: postStemResultaatPerFractie
-      description: "Registreer een Stemresultatenperfractie"
+      operationId: poststemresultaatperfractie
+      description: "<body><p>Het vastleggen van een Stemresultaatperfractie</p></body>"
+      parameters: 
+        - in: path
+          name: stemresultaatperfractieidentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+        - in: query
+          name: fields
+          description: ""
+          required: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/StemresultaatPerFractieHal'
       responses:
         '201':
-          description: ''
+          description: "OK"
+          headers:
+            Location:
+              description: "URI van de nieuwe resource"
+              schema:
+                type: string
+                format: uri
+                example: '/stemresultatenperfractie/{stemresultaatperfractieidentificatie}/'
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/StemresultaatPerFractieHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Stemresultaten per fractie
+    put:
+      operationId: Putstemresultaatperfractie
+      description: "<body><p>Het wijzigen van een stemresultaatperfractie</p></body>"
+      parameters: 
+        - in: path
+          name: stemresultaatperfractieidentificatie
+          description: ""
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+        - in: query
+          name: fields
+          description: ""
+          required: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/StemresultaatPerFractieHal'
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
-            application/json:
+            application/hal+json:
               schema:
                 $ref: '#/components/schemas/StemresultaatPerFractie'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Stemresultatenperfractie
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/StemresultaatPerFractie'
-        required: true
-    put:
-      operationId: putStemResultaatPerFractie
-      description: "Wijzig een bestaand Stemresultatenperfractie"
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/StemresultaatPerFractie' 
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Stemresultatenperfractie
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/StemresultaatPerFractie'
-        required: true
-  /toezeggingen/{informatieobjectidentificatie}:
-    get:
-      operationId: getToezegging
-      description: "Het bericht dat de JSON/REST API voor het ophalen van toezegging gegevens retourneert."
-      parameters: 
-        - in: path
-          name: informatieobjectidentificatie
-          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
-          required: true
-          schema:
-            type: string
-            maxLength: 40
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/Toezegging'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
-      - Toezeggingen
-    delete:
-      operationId: delToezegging
-      description: "Het bericht dat de JSON/REST API voor het verwijderen van een Toezegging."
-      parameters: 
-        - in: path
-          name: informatieobjectidentificatie
-          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
-          required: true
-          schema:
-            type: string
-            maxLength: 40
-      responses:
-        "204":
-          description: ""
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/problem+json:
-              schema:
-                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-        - Toezeggingen
+      - Stemresultataen per fractie
   /toezeggingen:
     get:
-      operationId: getToezeggingen
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een collectie toezeggingen retourneert."
+      operationId: Gettoezeggingen
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een collectie toezeggingen retourneert.</p></body>"
       parameters: 
         - in: query
           name: page
@@ -4731,21 +5113,21 @@ paths:
             minimum: 1
         - in: query
           name: auteur
-          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creëren van de inhoud van het INFORMATIEOBJECT. Het kan zowel een medewerker of organisatorische eenheid van de zaakbehandelende organisatie betreffen als een externe partij (persoon of organisatie). Het betreft het Dublin Core metadata-element ‘Creator’ met als toelichting: Examples of Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity. Van een ontvangen informatieobject kan de afzender de auteur zijn maar dat kan ook een ander zijn bijvoorbeeld in het geval dat de afzender een document van een derde meestuurt. Indien het informatieobject in een geautomatiseerd proces is vervaardigd, dan wordt als auteur vermeld degene die dat informatieobject ondertekend zou hebben dan wel, bij informatieobjecten waarbij van ondertekening geen sprake is (zoals bijvoorbeeld bij het omzetten van de zaakgegevens naar een duurzaam bewaarbaar informatieobject in pdf), degene die verantwoordelijk is voor de inhoud van het informatieobject vanuit zijn of haar rol bij de zaak (veelal degene in de rol van Zaakcoördinator). De naamgegevens van de auteur zijnde een betrokkene die in een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur niet in een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk persoon of organisatie zijnde de auteur. In het laatste geval verdient het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap wordt uitgeoefend."
+          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creÃ«ren van de inhoud van het INFORMATIEOBJECT. Het kan zowel een medewerker of organisatorische eenheid van de zaakbehandelende organisatie betreffen als een externe partij (persoon of organisatie). Het betreft het Dublin Core metadata-element â€˜Creatorâ€™ met als toelichting: Examples of Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity. Van een ontvangen informatieobject kan de afzender de auteur zijn maar dat kan ook een ander zijn bijvoorbeeld in het geval dat de afzender een document van een derde meestuurt. Indien het informatieobject in een geautomatiseerd proces is vervaardigd, dan wordt als auteur vermeld degene die dat informatieobject ondertekend zou hebben dan wel, bij informatieobjecten waarbij van ondertekening geen sprake is (zoals bijvoorbeeld bij het omzetten van de zaakgegevens naar een duurzaam bewaarbaar informatieobject in pdf), degene die verantwoordelijk is voor de inhoud van het informatieobject vanuit zijn of haar rol bij de zaak (veelal degene in de rol van ZaakcoÃ¶rdinator). De naamgegevens van de auteur zijnde een betrokkene die in een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur niet in een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk persoon of organisatie zijnde de auteur. In het laatste geval verdient het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap wordt uitgeoefend."
           required: false
           schema:
             type: string
             maxLength: 200
         - in: query
           name: bronorganisatie
-          description: "bronorganisatie bronorganisatie Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Het betreft het RSIN (Rechtspersonen en Samenwerkingsverbanden InformatieNummer) zoals dat door de KvK in het NHR aan elk rechtspersoon en samenwerkingsverband is toegekend. Dit identificeert uniek de organisatie, zijnde een rechtspersoon of samenwerkingsverband, dat het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Met het laatste doelen we er op dat bij uitwisseling van een informatieobject tussen samenwerkende organisaties de unieke aanduiding van het informatieobject niet wijzigt mits de ontvangende organisatie geen wijzigingen in het informatieobject aanbrengt. In het laatste geval ontstaat een nieuw informatieobject. Het RSIN staat in het Handelsregister (NHR) en op het daaraan te ontlenen uittreksel. Deze attribuutsoort vormt tezamen met de Informatieobjectidentificatie de unieke aanduiding van een informatieobject voor geheel Nederland. De waarde van dit attribuutsoort wijzigt niet, ook niet indien (de behandeling van) het informatieobject over zou gaan naar een andere organisatie. Er is immers maar één organisatie die het informatieobject gecreëerd of als eerste vastgelegd heeft. De in het NHR voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden."
+          description: "bronorganisatie bronorganisatie Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Het betreft het RSIN (Rechtspersonen en Samenwerkingsverbanden InformatieNummer) zoals dat door de KvK in het NHR aan elk rechtspersoon en samenwerkingsverband is toegekend. Dit identificeert uniek de organisatie, zijnde een rechtspersoon of samenwerkingsverband, dat het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Met het laatste doelen we er op dat bij uitwisseling van een informatieobject tussen samenwerkende organisaties de unieke aanduiding van het informatieobject niet wijzigt mits de ontvangende organisatie geen wijzigingen in het informatieobject aanbrengt. In het laatste geval ontstaat een nieuw informatieobject. Het RSIN staat in het Handelsregister (NHR) en op het daaraan te ontlenen uittreksel. Deze attribuutsoort vormt tezamen met de Informatieobjectidentificatie de unieke aanduiding van een informatieobject voor geheel Nederland. De waarde van dit attribuutsoort wijzigt niet, ook niet indien (de behandeling van) het informatieobject over zou gaan naar een andere organisatie. Er is immers maar Ã©Ã©n organisatie die het informatieobject gecreÃ«erd of als eerste vastgelegd heeft. De in het NHR voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden."
           required: false
           schema:
             type: integer
             maximum: 9.99999999E8
         - in: query
           name: creatiedatum
-          description: "creatiedatum creatiedatum Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Deze datum verwijst gewoonlijk naar de creatie van het INFORMATIEOBJECT. Het betreft het Dublin Core metadata-element ‘Date’ met als toelichting: Typically, Date will be associated with the creation or availability of the resource. Recommended best practice for encoding the date value is defined in a profile of ISO 8601 (W3CDTF) and includes (among others) dates of the form YYYY-MM-DD. Alle geldige datums gelegen op of voor de huidige datum en tijd"
+          description: "creatiedatum creatiedatum Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Deze datum verwijst gewoonlijk naar de creatie van het INFORMATIEOBJECT. Het betreft het Dublin Core metadata-element â€˜Dateâ€™ met als toelichting: Typically, Date will be associated with the creation or availability of the resource. Recommended best practice for encoding the date value is defined in a profile of ISO 8601 (W3CDTF) and includes (among others) dates of the form YYYY-MM-DD. Alle geldige datums gelegen op of voor de huidige datum en tijd"
           required: false
           schema:
             type: string
@@ -4757,9 +5139,10 @@ paths:
           schema:
             type: string
             format: date
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
         - in: query
           name: informatieobjectidentificatie
-          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
           required: false
           schema:
             type: string
@@ -4769,7 +5152,7 @@ paths:
           description: "de classificatie van de MOTIE"
           required: false
           schema:
-              $ref: "#/components/schemas/MotieType"
+            $ref: "#/components/schemas/MotieType"
         - in: query
           name: omschrijving
           description: "De omschrijving van het BESLUITVORMINGSSTUK Dit kan de omschrijving zijn van de MOTIE, het AMENDEMENT of het VOORSTEL"
@@ -4781,143 +5164,247 @@ paths:
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Pagination-Page:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
             X-Pagination-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                type: object
-                properties:
-                  _links:
-                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
-                  _embedded:
-                    type: object
-                    properties:
-                      toezeggingen:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Toezegging'
+                $ref: '#/components/schemas/ToezeggingHalCollectie'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
       - Toezeggingen
-    post:
-      operationId: postToezegging
-      description: "Registreer een Toezegging"
+  /toezeggingen/{informatieobjectidentificatie}:
+    delete:
+      operationId: deltoezegging
+      description: "<body><p>Het bericht dat de JSON/REST API voor het verwijderen van gegevens van een Toezegging</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
       responses:
-        '201':
-          description: ''
+        '200':
+          description: "Verwijderactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Toezegging'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+        '204':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/204"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+      tags: 
       - Toezeggingen
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Toezegging'
-        required: true
-    put:
-      operationId: putToezegging
-      description: "Wijzig een bestaand Toezegging"
+    get:
+      operationId: Gettoezegging
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van toezegging gegevens retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
       responses:
         '200':
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/Toezegging' 
+                $ref: '#/components/schemas/ToezeggingHal'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
-      tags:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
       - Toezeggingen
+    post:
+      operationId: posttoezegging
+      description: "<body><p>Het vastleggen van een Stemresultaatperfractie</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
       requestBody:
         content:
-          application/json:
+          application/hal+json:
             schema:
-              $ref: '#/components/schemas/Toezegging'
-        required: true
+                $ref: '#/components/schemas/ToezeggingHal'
+      responses:
+        '201':
+          description: "OK"
+          headers:
+            Location:
+              description: "URI van de nieuwe resource"
+              schema:
+                type: string
+                format: uri
+                example: '/toezeggingen/{informatieobjectidentificatie}/'
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ToezeggingHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Toezeggingen
+    put:
+      operationId: Puttoezegging
+      description: "<body><p>Het wijzigen van een toezegging</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/ToezeggingHal'
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/Toezegging'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Toezeggingen
   /vergaderingen:
     get:
-      operationId: getVergaderingen
-      description: "Het bericht dat de JSON/REST API voor het ophalen van vergaderingsgegevens retourneert."
+      operationId: Getvergaderingen
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van vergaderingsgegevens retourneert.</p></body>"
       parameters: 
         - in: query
           name: page
@@ -4926,7 +5413,6 @@ paths:
           schema:
             type: integer
             minimum: 1
-        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/parameters.yaml#/expand"
         - in: query
           name: naam
           description: "De naam van de vergadering"
@@ -4939,7 +5425,7 @@ paths:
           description: "De status van de vergadering"
           required: false
           schema:
-              $ref: "#/components/schemas/VergaderingStatus"
+            $ref: "#/components/schemas/VergaderingStatus"
         - in: query
           name: vergaderdatum
           description: "De datum van de VERGADERING"
@@ -4952,149 +5438,197 @@ paths:
           description: "De type-aanduiding van de vergadering."
           required: false
           schema:
-              $ref: "#/components/schemas/VergaderingsType"
+            $ref: "#/components/schemas/VergaderingsType"
       responses:
         '200':
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Pagination-Page:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
             X-Pagination-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                type: object
-                properties:
-                  _links:
-                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
-                  _embedded:
-                    type: object
-                    properties:
-                      vergaderingen:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Vergadering'
+                $ref: '#/components/schemas/VergaderingHalCollectie'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Vergaderingen
+  /vergaderingen/{vergaderingsidentificatie}:
+    delete:
+      operationId: devergadering
+      description: "<body><p>Het bericht dat de JSON/REST API voor het verwijderen van gegevens van een Vergadering</p></body>"
+      parameters: 
+        - in: path
+          name: vergaderingsidentificatie
+          description: "De identificatie een VERGADERING De eerste vier karakter zijn de gemeentecode, gevolgd door een volgnummer van 7 cijfers met voorloopnullen."
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+          example: 1234567890
+      responses:
+        '200':
+          description: "Verwijderactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+        '204':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/204"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+      tags: 
+      - Vergaderingen
+    get:
+      operationId: Getvergadering
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van vergaderingsgegevens retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: vergaderingsidentificatie
+          description: "De identificatie een VERGADERING De eerste vier karakter zijn de gemeentecode, gevolgd door een volgnummer van 7 cijfers met voorloopnullen."
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+          example: 1234567890
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/VergaderingHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
       - Vergaderingen
     post:
-      operationId: postVergadering
-      description: "Registreer een Vergadering"
+      operationId: postvergadering
+      description: "<body><p>Het vastleggen van een Stemresultaatperfractie</p></body>"
+      parameters: 
+        - in: path
+          name: vergaderingsidentificatie
+          description: "De identificatie een VERGADERING De eerste vier karakter zijn de gemeentecode, gevolgd door een volgnummer van 7 cijfers met voorloopnullen."
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+          example: 1234567890
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/VergaderingHal'
       responses:
         '201':
-          description: ''
+          description: "OK"
           headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/json:
+            Location:
+              description: "URI van de nieuwe resource"
               schema:
-                $ref: '#/components/schemas/Vergadering'
+                type: string
+                format: uri
+                example: '/vergaderingen/{vergaderingsidentificatie}/1234567890'
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/VergaderingHal'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
-      tags:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
       - Vergaderingen
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Vergadering'
-        required: true
     put:
-      operationId: putVergadering
-      description: "Wijzig een bestaand Vergadering"
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/Vergadering' 
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Vergaderingen
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Vergadering'
-        required: true
-  /vergaderingen/{vergaderingsidentificatie}:
-    get:
-      operationId: getVergadering
-      description: "Het bericht dat de JSON/REST API voor het ophalen van vergaderingsgegevens retourneert."
+      operationId: Putvergadering
+      description: "<body><p>Het wijzigen van een vergadering</p></body>"
       parameters: 
         - in: path
           name: vergaderingsidentificatie
@@ -5104,94 +5638,57 @@ paths:
             type: string
             maxLength: 10
           example: 1234567890
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/VergaderingHal'
       responses:
         '200':
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/Vergadering'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
       - Vergaderingen
-    delete:
-      operationId: delVergadering
-      description: "Het bericht dat de JSON/REST API voor het verwijderen van een Vergadering."
-      parameters: 
-        - in: path
-          name: vergaderingsidentificatie
-          description: "De identificatie een VERGADERING De eerste vier karakter zijn de gemeentecode, gevolgd door een volgnummer van 7 cijfers met voorloopnullen."
-          required: true
-          schema:
-            type: string
-            maxLength: 10
-          example: 1234567890
-      responses:
-        "204":
-          description: ""
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/problem+json:
-              schema:
-                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-        - Vergaderingen
   /voorstellen:
     get:
-      operationId: getVoorstellen
-      description: "Het bericht dat de JSON/REST API voor het ophalen van voorstelgegevens retourneert."
+      operationId: Getvoorstellen
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van vergaderingsgegevens retourneert.</p></body>"
       parameters: 
         - in: query
           name: page
@@ -5202,21 +5699,21 @@ paths:
             minimum: 1
         - in: query
           name: auteur
-          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creëren van de inhoud van het INFORMATIEOBJECT. Het kan zowel een medewerker of organisatorische eenheid van de zaakbehandelende organisatie betreffen als een externe partij (persoon of organisatie). Het betreft het Dublin Core metadata-element ‘Creator’ met als toelichting: Examples of Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity. Van een ontvangen informatieobject kan de afzender de auteur zijn maar dat kan ook een ander zijn bijvoorbeeld in het geval dat de afzender een document van een derde meestuurt. Indien het informatieobject in een geautomatiseerd proces is vervaardigd, dan wordt als auteur vermeld degene die dat informatieobject ondertekend zou hebben dan wel, bij informatieobjecten waarbij van ondertekening geen sprake is (zoals bijvoorbeeld bij het omzetten van de zaakgegevens naar een duurzaam bewaarbaar informatieobject in pdf), degene die verantwoordelijk is voor de inhoud van het informatieobject vanuit zijn of haar rol bij de zaak (veelal degene in de rol van Zaakcoördinator). De naamgegevens van de auteur zijnde een betrokkene die in een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur niet in een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk persoon of organisatie zijnde de auteur. In het laatste geval verdient het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap wordt uitgeoefend."
+          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creÃ«ren van de inhoud van het INFORMATIEOBJECT. Het kan zowel een medewerker of organisatorische eenheid van de zaakbehandelende organisatie betreffen als een externe partij (persoon of organisatie). Het betreft het Dublin Core metadata-element â€˜Creatorâ€™ met als toelichting: Examples of Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity. Van een ontvangen informatieobject kan de afzender de auteur zijn maar dat kan ook een ander zijn bijvoorbeeld in het geval dat de afzender een document van een derde meestuurt. Indien het informatieobject in een geautomatiseerd proces is vervaardigd, dan wordt als auteur vermeld degene die dat informatieobject ondertekend zou hebben dan wel, bij informatieobjecten waarbij van ondertekening geen sprake is (zoals bijvoorbeeld bij het omzetten van de zaakgegevens naar een duurzaam bewaarbaar informatieobject in pdf), degene die verantwoordelijk is voor de inhoud van het informatieobject vanuit zijn of haar rol bij de zaak (veelal degene in de rol van ZaakcoÃ¶rdinator). De naamgegevens van de auteur zijnde een betrokkene die in een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur niet in een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk persoon of organisatie zijnde de auteur. In het laatste geval verdient het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap wordt uitgeoefend."
           required: false
           schema:
             type: string
             maxLength: 200
         - in: query
           name: bronorganisatie
-          description: "bronorganisatie bronorganisatie Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Het betreft het RSIN (Rechtspersonen en Samenwerkingsverbanden InformatieNummer) zoals dat door de KvK in het NHR aan elk rechtspersoon en samenwerkingsverband is toegekend. Dit identificeert uniek de organisatie, zijnde een rechtspersoon of samenwerkingsverband, dat het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Met het laatste doelen we er op dat bij uitwisseling van een informatieobject tussen samenwerkende organisaties de unieke aanduiding van het informatieobject niet wijzigt mits de ontvangende organisatie geen wijzigingen in het informatieobject aanbrengt. In het laatste geval ontstaat een nieuw informatieobject. Het RSIN staat in het Handelsregister (NHR) en op het daaraan te ontlenen uittreksel. Deze attribuutsoort vormt tezamen met de Informatieobjectidentificatie de unieke aanduiding van een informatieobject voor geheel Nederland. De waarde van dit attribuutsoort wijzigt niet, ook niet indien (de behandeling van) het informatieobject over zou gaan naar een andere organisatie. Er is immers maar één organisatie die het informatieobject gecreëerd of als eerste vastgelegd heeft. De in het NHR voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden."
+          description: "bronorganisatie bronorganisatie Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Het betreft het RSIN (Rechtspersonen en Samenwerkingsverbanden InformatieNummer) zoals dat door de KvK in het NHR aan elk rechtspersoon en samenwerkingsverband is toegekend. Dit identificeert uniek de organisatie, zijnde een rechtspersoon of samenwerkingsverband, dat het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Met het laatste doelen we er op dat bij uitwisseling van een informatieobject tussen samenwerkende organisaties de unieke aanduiding van het informatieobject niet wijzigt mits de ontvangende organisatie geen wijzigingen in het informatieobject aanbrengt. In het laatste geval ontstaat een nieuw informatieobject. Het RSIN staat in het Handelsregister (NHR) en op het daaraan te ontlenen uittreksel. Deze attribuutsoort vormt tezamen met de Informatieobjectidentificatie de unieke aanduiding van een informatieobject voor geheel Nederland. De waarde van dit attribuutsoort wijzigt niet, ook niet indien (de behandeling van) het informatieobject over zou gaan naar een andere organisatie. Er is immers maar Ã©Ã©n organisatie die het informatieobject gecreÃ«erd of als eerste vastgelegd heeft. De in het NHR voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden."
           required: false
           schema:
             type: integer
             maximum: 9.99999999E8
         - in: query
           name: creatiedatum
-          description: "creatiedatum creatiedatum Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Deze datum verwijst gewoonlijk naar de creatie van het INFORMATIEOBJECT. Het betreft het Dublin Core metadata-element ‘Date’ met als toelichting: Typically, Date will be associated with the creation or availability of the resource. Recommended best practice for encoding the date value is defined in a profile of ISO 8601 (W3CDTF) and includes (among others) dates of the form YYYY-MM-DD. Alle geldige datums gelegen op of voor de huidige datum en tijd"
+          description: "creatiedatum creatiedatum Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Deze datum verwijst gewoonlijk naar de creatie van het INFORMATIEOBJECT. Het betreft het Dublin Core metadata-element â€˜Dateâ€™ met als toelichting: Typically, Date will be associated with the creation or availability of the resource. Recommended best practice for encoding the date value is defined in a profile of ISO 8601 (W3CDTF) and includes (among others) dates of the form YYYY-MM-DD. Alle geldige datums gelegen op of voor de huidige datum en tijd"
           required: false
           schema:
             type: string
@@ -5224,13 +5721,6 @@ paths:
         - in: query
           name: datumingediend
           description: "De datum waarop het BESLUITVORMINGSSTUK is ingediend"
-          required: false
-          schema:
-            type: string
-            format: date
-        - in: query
-          name: ontvangstdatum
-          description: "ontvangstdatum ontvangstdatum De datum waarop het INFORMATIEOBJECT ontvangen is. De datum waarop het INFORMATIEOBJECT ontvangen is. Het gaat hier om de datum waarop het INFORMATIEOBJECT ontvangen is door de zaakbehandelende organisatie(s), dus niet door een specifieke afdeling of medewerker daarvan. Alle geldige datums gelegen op, voor of na de huidige datum en tijd"
           required: false
           schema:
             type: string
@@ -5244,14 +5734,14 @@ paths:
             maxLength: 100
         - in: query
           name: titel
-          description: "titel titel De naam waaronder het INFORMATIEOBJECT formeel bekend is. De naam waaronder het INFORMATIEOBJECT formeel bekend is. Het betreft het Dublin Core metadata-element ‘Title’ met als toelichting: Typically, Title will be a name by which the resource is formally known. alle alfanumerieke tekens"
+          description: "titel titel De naam waaronder het INFORMATIEOBJECT formeel bekend is. De naam waaronder het INFORMATIEOBJECT formeel bekend is. Het betreft het Dublin Core metadata-element â€˜Titleâ€™ met als toelichting: Typically, Title will be a name by which the resource is formally known. alle alfanumerieke tekens"
           required: false
           schema:
             type: string
             maxLength: 200
         - in: query
           name: versie
-          description: "versie versie Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Het gaat hier om een versienummer zoals ‘0.2’ en 1.0’. Ofschoon we er voor gekozen hebben om zowel dit attribuuttype als het attribuuttype Status optioneel te verklaren, ware het aan te bevelen bij elk documemt in ieder geval één van beide attributen van een waarde te voorzien. Nb: De attribuutsoort is in versie 2.0 verplaatst van ENKELVOUDIG INFORMATIEOBJECT naar INFORMATIEOBJECT. Alle alfanumerieke tekens m.u.v. diacrieten"
+          description: "versie versie Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Het gaat hier om een versienummer zoals â€˜0.2â€™ en 1.0â€™. Ofschoon we er voor gekozen hebben om zowel dit attribuuttype als het attribuuttype Status optioneel te verklaren, ware het aan te bevelen bij elk documemt in ieder geval Ã©Ã©n van beide attributen van een waarde te voorzien. Nb: De attribuutsoort is in versie 2.0 verplaatst van ENKELVOUDIG INFORMATIEOBJECT naar INFORMATIEOBJECT. Alle alfanumerieke tekens m.u.v. diacrieten"
           required: false
           schema:
             type: string
@@ -5261,333 +5751,246 @@ paths:
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Pagination-Page:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
             X-Pagination-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                type: object
-                properties:
-                  _links:
-                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
-                  _embedded:
-                    type: object
-                    properties:
-                      voorstellen:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Voorstel'
+                $ref: '#/components/schemas/VoorstelHalCollectie'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Voorstellen
+  /voorstellen/{informatieobjectidentificatie}:
+    delete:
+      operationId: delvoorstel
+      description: "<body><p>Het bericht dat de JSON/REST API voor het verwijderen van gegevens van een Voorstel</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+      responses:
+        '200':
+          description: "Verwijderactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+        '204':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/204"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+      tags: 
+      - Voorstellen
+    get:
+      operationId: Getvoorstel
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van voorstel gegevens retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/VoorstelHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
       - Voorstellen
     post:
-      operationId: postVoorstel
-      description: "Registreer een Voorstel"
+      operationId: postvoorstel
+      description: "<body><p>Het vastleggen van een Voorstel</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/VoorstelHal'
       responses:
         '201':
-          description: ''
+          description: "OK"
           headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/json:
+            Location:
+              description: "URI van de nieuwe resource"
               schema:
-                $ref: '#/components/schemas/Voorstel'
+                type: string
+                format: uri
+                example: '/voorstellen/{informatieobjectidentificatie}/'
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/VoorstelHal'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
-      tags:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
       - Voorstellen
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Voorstel'
-        required: true
     put:
-      operationId: putVoorstel
-      description: "Wijzig een bestaand Voorstel"
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/Voorstel' 
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags:
-      - Voorstellen
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Voorstel'
-        required: true
-  /voorstellen/{informatieobjectidentificatie}:
-    get:
-      operationId: getVoorstel
-      description: "Het bericht dat de JSON/REST API voor het ophalen van voorstel gegevens retourneert."
+      operationId: Putvoorstel
+      description: "<body><p>Het wijzigen van een voorstel</p></body>"
       parameters: 
         - in: path
           name: informatieobjectidentificatie
-          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
           required: true
           schema:
             type: string
             maxLength: 40
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/VoorstelHal'
       responses:
         '200':
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/Voorstel'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
       - Voorstellen
-    delete:
-      operationId: delVoorstel
-      description: "Het bericht dat de JSON/REST API voor het verwijderen van een Voorstel."
-      parameters: 
-        - in: path
-          name: informatieobjectidentificatie
-          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
-          required: true
-          schema:
-            type: string
-            maxLength: 40
-      responses:
-        "204":
-          description: ""
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/problem+json:
-              schema:
-                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-        - Voorstellen
-  /vragen/{informatieobjectidentificatie}:
-    get:
-      operationId: getVraag
-      description: "Het bericht dat de JSON/REST API voor het ophalen van vraag-gegevens retourneert."
-      parameters: 
-        - in: path
-          name: informatieobjectidentificatie
-          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
-          required: true
-          schema:
-            type: string
-            maxLength: 40
-      responses:
-        '200':
-          description: "Zoekactie geslaagd"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/Vraag'
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-      - Vragen
-    delete:
-      operationId: delVraag
-      description: "Het bericht dat de JSON/REST API voor het verwijderen van een Vraag."
-      parameters: 
-        - in: path
-          name: informatieobjectidentificatie
-          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
-          required: true
-          schema:
-            type: string
-            maxLength: 40
-      responses:
-        "204":
-          description: ""
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/problem+json:
-              schema:
-                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '404':
-          $ref: "#/components/responses/404"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags: 
-        - Vragen
   /vragen:
     get:
-      operationId: getVragen
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een collectie vragen retourneert."
+      operationId: Getvragen
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van een collectie vragen retourneert.</p></body>"
       parameters: 
         - in: query
           name: page
@@ -5598,42 +6001,35 @@ paths:
             minimum: 1
         - in: query
           name: auteur
-          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creëren van de inhoud van het INFORMATIEOBJECT. Het kan zowel een medewerker of organisatorische eenheid van de zaakbehandelende organisatie betreffen als een externe partij (persoon of organisatie). Het betreft het Dublin Core metadata-element ‘Creator’ met als toelichting: Examples of Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity. Van een ontvangen informatieobject kan de afzender de auteur zijn maar dat kan ook een ander zijn bijvoorbeeld in het geval dat de afzender een document van een derde meestuurt. Indien het informatieobject in een geautomatiseerd proces is vervaardigd, dan wordt als auteur vermeld degene die dat informatieobject ondertekend zou hebben dan wel, bij informatieobjecten waarbij van ondertekening geen sprake is (zoals bijvoorbeeld bij het omzetten van de zaakgegevens naar een duurzaam bewaarbaar informatieobject in pdf), degene die verantwoordelijk is voor de inhoud van het informatieobject vanuit zijn of haar rol bij de zaak (veelal degene in de rol van Zaakcoördinator). De naamgegevens van de auteur zijnde een betrokkene die in een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur niet in een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk persoon of organisatie zijnde de auteur. In het laatste geval verdient het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap wordt uitgeoefend."
+          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creÃ«ren van de inhoud van het INFORMATIEOBJECT. Het kan zowel een medewerker of organisatorische eenheid van de zaakbehandelende organisatie betreffen als een externe partij (persoon of organisatie). Het betreft het Dublin Core metadata-element â€˜Creatorâ€™ met als toelichting: Examples of Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity. Van een ontvangen informatieobject kan de afzender de auteur zijn maar dat kan ook een ander zijn bijvoorbeeld in het geval dat de afzender een document van een derde meestuurt. Indien het informatieobject in een geautomatiseerd proces is vervaardigd, dan wordt als auteur vermeld degene die dat informatieobject ondertekend zou hebben dan wel, bij informatieobjecten waarbij van ondertekening geen sprake is (zoals bijvoorbeeld bij het omzetten van de zaakgegevens naar een duurzaam bewaarbaar informatieobject in pdf), degene die verantwoordelijk is voor de inhoud van het informatieobject vanuit zijn of haar rol bij de zaak (veelal degene in de rol van ZaakcoÃ¶rdinator). De naamgegevens van de auteur zijnde een betrokkene die in een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur niet in een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk persoon of organisatie zijnde de auteur. In het laatste geval verdient het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap wordt uitgeoefend."
           required: false
           schema:
             type: string
             maxLength: 200
         - in: query
           name: bronorganisatie
-          description: "bronorganisatie bronorganisatie Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Het betreft het RSIN (Rechtspersonen en Samenwerkingsverbanden InformatieNummer) zoals dat door de KvK in het NHR aan elk rechtspersoon en samenwerkingsverband is toegekend. Dit identificeert uniek de organisatie, zijnde een rechtspersoon of samenwerkingsverband, dat het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Met het laatste doelen we er op dat bij uitwisseling van een informatieobject tussen samenwerkende organisaties de unieke aanduiding van het informatieobject niet wijzigt mits de ontvangende organisatie geen wijzigingen in het informatieobject aanbrengt. In het laatste geval ontstaat een nieuw informatieobject. Het RSIN staat in het Handelsregister (NHR) en op het daaraan te ontlenen uittreksel. Deze attribuutsoort vormt tezamen met de Informatieobjectidentificatie de unieke aanduiding van een informatieobject voor geheel Nederland. De waarde van dit attribuutsoort wijzigt niet, ook niet indien (de behandeling van) het informatieobject over zou gaan naar een andere organisatie. Er is immers maar één organisatie die het informatieobject gecreëerd of als eerste vastgelegd heeft. De in het NHR voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden."
+          description: "bronorganisatie bronorganisatie Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Het betreft het RSIN (Rechtspersonen en Samenwerkingsverbanden InformatieNummer) zoals dat door de KvK in het NHR aan elk rechtspersoon en samenwerkingsverband is toegekend. Dit identificeert uniek de organisatie, zijnde een rechtspersoon of samenwerkingsverband, dat het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Met het laatste doelen we er op dat bij uitwisseling van een informatieobject tussen samenwerkende organisaties de unieke aanduiding van het informatieobject niet wijzigt mits de ontvangende organisatie geen wijzigingen in het informatieobject aanbrengt. In het laatste geval ontstaat een nieuw informatieobject. Het RSIN staat in het Handelsregister (NHR) en op het daaraan te ontlenen uittreksel. Deze attribuutsoort vormt tezamen met de Informatieobjectidentificatie de unieke aanduiding van een informatieobject voor geheel Nederland. De waarde van dit attribuutsoort wijzigt niet, ook niet indien (de behandeling van) het informatieobject over zou gaan naar een andere organisatie. Er is immers maar Ã©Ã©n organisatie die het informatieobject gecreÃ«erd of als eerste vastgelegd heeft. De in het NHR voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden."
           required: false
           schema:
             type: integer
             maximum: 9.99999999E8
         - in: query
           name: creatiedatum
-          description: "creatiedatum creatiedatum Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Deze datum verwijst gewoonlijk naar de creatie van het INFORMATIEOBJECT. Het betreft het Dublin Core metadata-element ‘Date’ met als toelichting: Typically, Date will be associated with the creation or availability of the resource. Recommended best practice for encoding the date value is defined in a profile of ISO 8601 (W3CDTF) and includes (among others) dates of the form YYYY-MM-DD. Alle geldige datums gelegen op of voor de huidige datum en tijd"
-          required: false
-          schema:
-            type: string
-            format: date
-        - in: query
-          name: ontvangstdatum
-          description: "ontvangstdatum ontvangstdatum De datum waarop het INFORMATIEOBJECT ontvangen is. De datum waarop het INFORMATIEOBJECT ontvangen is. Het gaat hier om de datum waarop het INFORMATIEOBJECT ontvangen is door de zaakbehandelende organisatie(s), dus niet door een specifieke afdeling of medewerker daarvan. Alle geldige datums gelegen op, voor of na de huidige datum en tijd"
+          description: "creatiedatum creatiedatum Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Deze datum verwijst gewoonlijk naar de creatie van het INFORMATIEOBJECT. Het betreft het Dublin Core metadata-element â€˜Dateâ€™ met als toelichting: Typically, Date will be associated with the creation or availability of the resource. Recommended best practice for encoding the date value is defined in a profile of ISO 8601 (W3CDTF) and includes (among others) dates of the form YYYY-MM-DD. Alle geldige datums gelegen op of voor de huidige datum en tijd"
           required: false
           schema:
             type: string
             format: date
         - in: query
           name: titel
-          description: "titel titel De naam waaronder het INFORMATIEOBJECT formeel bekend is. De naam waaronder het INFORMATIEOBJECT formeel bekend is. Het betreft het Dublin Core metadata-element ‘Title’ met als toelichting: Typically, Title will be a name by which the resource is formally known. alle alfanumerieke tekens"
+          description: "titel titel De naam waaronder het INFORMATIEOBJECT formeel bekend is. De naam waaronder het INFORMATIEOBJECT formeel bekend is. Het betreft het Dublin Core metadata-element â€˜Titleâ€™ met als toelichting: Typically, Title will be a name by which the resource is formally known. alle alfanumerieke tekens"
           required: false
           schema:
             type: string
             maxLength: 200
         - in: query
           name: versie
-          description: "versie versie Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Het gaat hier om een versienummer zoals ‘0.2’ en 1.0’. Ofschoon we er voor gekozen hebben om zowel dit attribuuttype als het attribuuttype Status optioneel te verklaren, ware het aan te bevelen bij elk documemt in ieder geval één van beide attributen van een waarde te voorzien. Nb: De attribuutsoort is in versie 2.0 verplaatst van ENKELVOUDIG INFORMATIEOBJECT naar INFORMATIEOBJECT. Alle alfanumerieke tekens m.u.v. diacrieten"
+          description: "versie versie Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Het gaat hier om een versienummer zoals â€˜0.2â€™ en 1.0â€™. Ofschoon we er voor gekozen hebben om zowel dit attribuuttype als het attribuuttype Status optioneel te verklaren, ware het aan te bevelen bij elk documemt in ieder geval Ã©Ã©n van beide attributen van een waarde te voorzien. Nb: De attribuutsoort is in versie 2.0 verplaatst van ENKELVOUDIG INFORMATIEOBJECT naar INFORMATIEOBJECT. Alle alfanumerieke tekens m.u.v. diacrieten"
           required: false
           schema:
             type: string
@@ -5649,158 +6045,272 @@ paths:
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
             X-Pagination-Page:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
             X-Pagination-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
             X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
             X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
             X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                type: object
-                properties:
-                  _links:
-                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
-                  _embedded:
-                    type: object
-                    properties:
-                      vragen:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Vraag'
+                $ref: '#/components/schemas/VraagHalCollectie'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
       tags: 
       - Vragen
-    post:
-      operationId: postVraag
-      description: "Registreer een Vraag"
+  /vragen/{informatieobjectidentificatie}:
+    delete:
+      operationId: delvraag
+      description: "<body><p>Het bericht dat de JSON/REST API voor het verwijderen van gegevens van een Voorstel</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
       responses:
-        '201':
-          description: ''
+        '200':
+          description: "Verwijderactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Vraag'
-        '400':
-          $ref: "#/components/responses/400"
-        '401':
-          $ref: "#/components/responses/401"
-        '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
-        '409':
-          $ref: "#/components/responses/409"
-        '410':
-          $ref: "#/components/responses/410"
-        '415':
-          $ref: "#/components/responses/415"
-        '429':
-          $ref: "#/components/responses/429"
-        '500':
-          $ref: "#/components/responses/500"
-        'default':
-          $ref: "#/components/responses/default"
-      tags:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+        '204':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/204"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
+      tags: 
       - Vragen
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Vraag'
-        required: true
-    put:
-      operationId: putVraag
-      description: "Wijzig een bestaand Vraag"
+    get:
+      operationId: Getvraag
+      description: "<body><p>Het bericht dat de JSON/REST API voor het ophalen van vraag-gegevens retourneert.</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
       responses:
         '200':
           description: "Zoekactie geslaagd"
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/Vraag' 
+                $ref: '#/components/schemas/VraagHal'
         '400':
-          $ref: "#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "#/components/responses/403"
-        '406':
-          $ref: "#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/404"
         '409':
-          $ref: "#/components/responses/409"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
         '410':
-          $ref: "#/components/responses/410"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
         '415':
-          $ref: "#/components/responses/415"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
         '429':
-          $ref: "#/components/responses/429"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
         '500':
-          $ref: "#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "#/components/responses/default"
-      tags:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
       - Vragen
+    post:
+      operationId: postvraag
+      description: "<body><p>Het vastleggen van een Vragen</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
       requestBody:
         content:
-          application/json:
+          application/hal+json:
             schema:
-              $ref: '#/components/schemas/Vraag'
-        required: true
+                $ref: '#/components/schemas/VraagHal'
+      responses:
+        '201':
+          description: "OK"
+          headers:
+            Location:
+              description: "URI van de nieuwe resource"
+              schema:
+                type: string
+                format: uri
+                example: '/vragen/{informatieobjectidentificatie}/'
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/VraagHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Vragen
+    put:
+      operationId: Putvraag
+      description: "<body><p>Het wijzigen van een voorstel</p></body>"
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/VraagHal'
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/Vraag'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Vragen
 components:
   schemas:
+    AanwezigeDeelnemerHalCollectie:
+      type: "object"
+      properties:
+        _links:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+        _embedded:
+          type: "object"
+          properties:
+            aanwezigedeelnemers:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/AanwezigeDeelnemerHal"
+    AanwezigeDeelnemerHal:
+      allOf:
+      - $ref: "#/components/schemas/AanwezigeDeelnemer"
+      - type: "object"
+        properties:
+          _links:
+            $ref: "#/components/schemas/AanwezigeDeelnemer_links"
     AanwezigeDeelnemer:
       type: "object"
-      description: "De NATUURLIJKe PERSOON die deelneemt aan een VERGADERING"
+      description: "<body>De NATUURLIJKe PERSOON die deelneemt aan een VERGADERING</body>"
       properties:
-        "@context":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@type":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
         aanvangAanwezigheid:
           type: "string"
           title: "Aanvang aanwezigheid"
-          description: "De aanvang van de aanwezigheid"
+          description: "<body>De aanvang van de aanwezigheid</body>"
         aanwezigdeDeelnemerIdentificatie:
           type: "string"
           title: "aanwezigdeDeelnemerIdentificatie"
@@ -5809,88 +6319,96 @@ components:
         deelnemerspositie:
           type: "string"
           title: "Deelnemerspositie"
-          description: "De plek waar een deelnemer in de zaal zit. Dit kan bijvoorbeeld\
-            \ een stoel of een console zijn. Dit kan o.a. van belang zijn voor de\
-            \ audio/video-verslaggeving."
+          description: "<body>De plek waar een deelnemer in de zaal zit.</body><body>Dit\
+            \ kan bijvoorbeeld een stoel of een console zijn. Dit kan o.a. van belang\
+            \ zijn voor de audio/video-verslaggeving.</body>"
         eindeAanwezigheid:
           type: "string"
           title: "Einde aanwezigheid"
-          description: "De einde van de aanwezigheid"
+          description: "<body>De einde van de aanwezigheid</body>"
         rolnaam:
           $ref: "#/components/schemas/RolNaam"
         vertegenwoordigtOrganisatie:
           type: "string"
           title: "Vertegenwoordigde organisatie"
-          description: "De naam van de organisatie die iemand vertegenwoordigt."
+          description: "<body>De naam van de organisatie die iemand vertegenwoordigt.</body>"
           maxLength: 100
+    AgendapuntHalCollectie:
+      type: "object"
+      properties:
         _links:
-          $ref: "#/components/schemas/AanwezigeDeelnemer_links"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+        _embedded:
+          type: "object"
+          properties:
+            agendapunten:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/AgendapuntHal"
+    AgendapuntHal:
+      allOf:
+      - $ref: "#/components/schemas/Agendapunt"
+      - type: "object"
+        properties:
+          _links:
+            $ref: "#/components/schemas/Agendapunt_links"
     Agendapunt:
       type: "object"
-      description: "Een onderdeel van de agenda dat als één geheel wordt behandeld.\
-        \ Een AGENDAPUNT kan weer onderverdeeld zijn naar subAGENDAPUNTen."
+      description: "<body>Een onderdeel van de agenda dat als Ã©Ã©n geheel wordt behandeld.\
+        \ Een AGENDAPUNT kan weer onderverdeeld zijn naar subAGENDAPUNTen.</body>"
       required:
       - "agendapuntnummer"
       - "indicatieHamerstuk"
       - "indicatorBehandeld"
       - "indicatorBesloten"
       properties:
-        "@context":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@type":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
         agendapuntKenmerk:
           type: "string"
           title: "Agendapunt kenmerk"
-          description: "De weergave van het Agendapuntvolgnummer op de agenda. Dit\
+          description: "<body>De weergave van het Agendapuntvolgnummer op de agenda.</body><body>Dit\
             \ is de letterlijke volgorde van een Agendapunt wordt bij gehouden d.m.v.\
             \ attribuut 'Agendapuntvolgnummer'. Hoe het Agendapunt getoond wordt op\
-            \ de Agenda wordt beschreven met attribuut 'Agendapunt kenmerk'."
+            \ de Agenda wordt beschreven met attribuut 'Agendapunt kenmerk'.</body>"
           maxLength: 20
-        agendapuntnummer:
-          type: "string"
-          title: "Agendapuntnummer"
-          description: "Het nummer van het agendapunt op de agenda."
-          maxLength: 10
-          minLength: 1
         agendapuntOmschrijving:
           type: "string"
           title: "Agendapunt omschrijving"
-          description: "De omschrijving van het agendapunt"
+          description: "<body>De omschrijving van het agendapunt</body>"
+        agendapuntnummer:
+          type: "string"
+          title: "Agendapuntnummer"
+          description: "<body>Het nummer van het agendapunt op de agenda.</body>"
+          maxLength: 10
+          minLength: 1
         agendapuntvolgnummer:
           type: "string"
           title: "Agendapuntvolgnummer"
-          description: "Dit is het volgnummer van het AGENDAPUNT tijdens de vergadering.\
-            \ Dit is de letterlijke volgorde en zegt niets over hoe dit volgnummer\
-            \ getoond wordt. Hoe het Agendapunt getoond wordt op de Agenda wordt beschreven\
-            \ met attribuut 'Agendapunt kenmerk'."
+          description: "<body>Dit is het volgnummer van het AGENDAPUNT tijdens de\
+            \ vergadering.</body><body>Dit is de letterlijke volgorde en zegt niets\
+            \ over hoe dit volgnummer getoond wordt. Hoe het Agendapunt getoond wordt\
+            \ op de Agenda wordt beschreven met attribuut 'Agendapunt kenmerk'.</body>"
           maxLength: 3
         eindtijd:
           type: "string"
           title: "Eindtijd"
-          description: "De datum en tijdstip waarop de behandeling van de agendapunt\
-            \ is geëindigd Moet voor komen als Starttijd voorkomt"
+          description: "<body>De datum en tijdstip waarop de behandeling van de agendapunt\
+            \ is geÃ«indigd</body><body>Moet voor komen als Starttijd voorkomt</body>"
         geplandAgendapuntvolgnummer:
           type: "string"
           title: "Gepland agendapuntvolgnummer"
-          description: "Dit is het geplande volgnummer van het AGENDAPUNT van een\
-            \ vergadering."
+          description: "<body>Dit is het geplande volgnummer van het AGENDAPUNT van\
+            \ een vergadering.</body>"
           maxLength: 10
         geplandeEindtijd:
           type: "string"
           title: "Geplande eindtijd"
-          description: "De geplande datum en tijdstip waarop de behandeling van de\
-            \ agendapunt eindigt"
+          description: "<body>De geplande datum en tijdstip waarop de behandeling\
+            \ van de agendapunt eindigt</body>"
         geplandeStarttijd:
           type: "string"
           title: "Geplande starttijd"
-          description: "De geplande datum en tijdstip waarop de behandeling van de\
-            \ agendapunt start"
+          description: "<body>De geplande datum en tijdstip waarop de behandeling\
+            \ van de agendapunt start</body>"
         indicatieHamerstuk:
           type: "boolean"
           title: "Indicatie hamerstuk"
@@ -5899,250 +6417,198 @@ components:
         indicatorBehandeld:
           type: "boolean"
           title: "Indicator behandeld"
-          description: "Indicator geeft aan of het AGENDAPUNT is behandeld tijdens\
-            \ de VERGADERING. Is eventueel af te leiden als Starttijd en/of Eindtijd\
-            \ zijn ingevuld defaultwaarde = nee"
+          description: "<body>Indicator geeft aan of het AGENDAPUNT is behandeld tijdens\
+            \ de VERGADERING.</body><body>Is eventueel af te leiden als Starttijd\
+            \ en/of Eindtijd zijn ingevuld</body><body>defaultwaarde = nee</body>"
         indicatorBesloten:
           type: "boolean"
           title: "Indicator besloten"
-          description: "Indicator of een AGENDAPUNT besloten wordt behandeld defaultwaarde\
-            \ = nee"
+          description: "<body>Indicator of een AGENDAPUNT besloten wordt behandeld</body><body>defaultwaarde\
+            \ = nee</body>"
         starttijd:
           type: "string"
           title: "Starttijd"
-          description: "De datum en tijdstip waarop de behandeling van de agendapunt\
-            \ is gestart"
+          description: "<body>De datum en tijdstip waarop de behandeling van de agendapunt\
+            \ is gestart</body>"
+    AmendementHalCollectie:
+      type: "object"
+      properties:
         _links:
-          $ref: "#/components/schemas/Agendapunt_links"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+        _embedded:
+          type: "object"
+          properties:
+            amendementen:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/AmendementHal"
+    AmendementHal:
+      allOf:
+      - $ref: "#/components/schemas/Amendement"
+      - type: "object"
+        properties:
+          _links:
+            $ref: "#/components/schemas/Amendement_links"
     Amendement:
       allOf:
       - $ref: "#/components/schemas/Besluitvormingsstuk"
       - type: "object"
-        description: "Een AMENDEMENT is een voorstel tot wijziging van een raadsVOORSTEL\
-          \ Een aangenomen AMENDEMENT wordt onderdeel van een VOORSTEL"
+        description: "<body>Een AMENDEMENT is een voorstel tot wijziging van een raadsVOORSTEL</body><body>Een\
+          \ aangenomen AMENDEMENT wordt onderdeel van een VOORSTEL</body>"
         properties:
           toelichting:
             type: "string"
             title: "Toelichting"
-            description: "De toelichting op het AMENDEMENT"
-          _links:
-            $ref: "#/components/schemas/Amendement_links"
-    Motie:
+            description: "<body>De toelichting op het AMENDEMENT</body>"
+    AntwoordHalCollectie:
+      type: "object"
+      properties:
+        _links:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+        _embedded:
+          type: "object"
+          properties:
+            antwoorden:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/AntwoordHal"
+    AntwoordHal:
       allOf:
-      - $ref: "#/components/schemas/Besluitvormingsstuk"
+      - $ref: "#/components/schemas/Antwoord"
       - type: "object"
-        description: "Een MOTIE is een korte gemotiveerde verklaring over een onderwerp\
-          \ waardoor een mening, wens of verzoek wordt uitgesproken en is ingediend\
-          \ door een raadslid of een statenlid. Een motie begint met de reden van\
-          \ indiening en eindigt met de uitspraak. Een motie is juridisch niet bindend\
-          \ en wordt eerst ter stemming voorgelegd tijdens de VERGADERING van de gemeenteraad\
-          \ of provinciale staten. Een motie kan zelfstandig zijn of gekoppeld aan\
-          \ een voorstel dat ter bespreking voorligt."
         properties:
           _links:
-            $ref: "#/components/schemas/Motie_links"
-    Voorstel:
-      allOf:
-      - $ref: "#/components/schemas/Besluitvormingsstuk"
-      - type: "object"
-        description: "Een VOORSTEL is een plan waarover een BESLUIT genomen kan worden\
-          \ d.m.v. een STEMMING. Het college van B&W (gemeente) of de gedeputeerde\
-          \ staten (provincie) bereiden de meeste VOORSTELlen voor. Het VOORSTEL en\
-          \ eventuele AMENDEMENTen en inhoudelijke stukken beschrijven het VOORSTEL\
-          \ in detail. Vaak worden de VOORSTELlen eerst besproken in een meningsvormende\
-          \ ronde of in één van de (raads/staten)commissies. Er wordt gekeken of er\
-          \ voldoende informatie is om in de volgende besluitvormende VERGADERING\
-          \ van de gemeenteraad of gedeptueerde staten over dat voorstel een BESLUIT\
-          \ te nemen. In de besluitvormende vergadering wordt door de raadsleden of\
-          \ statenleden 'voor' of 'tegen' het VOORSTEL gestemd. Is de meerderheid\
-          \ 'voor' dan is het VOORSTEL aangenomen. Is de meerderheid 'tegen' dan is\
-          \ het VOORSTEL verworpen."
-        properties:
-          _links:
-            $ref: "#/components/schemas/Voorstel_links"
+            $ref: "#/components/schemas/Antwoord_links"
     Antwoord:
       allOf:
       - $ref: "#/components/schemas/EnkelvoudigInformatieobject"
       - type: "object"
-        description: "Het antwoord dat gegeven is door het college of de burgemeester\
+        description: "<body>Het antwoord dat gegeven is door het college of de burgemeester\
           \ (in geval van een gemeente) of door de commissaris of gedeputeerde staten\
-          \ (in geval van een provincie) op een gestelde vraag"
+          \ (in geval van een provincie) op een gestelde vraag</body>"
         properties:
           antwoordomschrijving:
             type: "string"
             title: "Antwoordomschrijving"
-            description: "De omschrijving van het antwoord"
+            description: "<body>De omschrijving van het antwoord</body>"
+    BesluitHalCollectie:
+      type: "object"
+      properties:
+        _links:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+        _embedded:
+          type: "object"
+          properties:
+            besluiten:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/BesluitHal"
+    BesluitHal:
+      allOf:
+      - $ref: "#/components/schemas/Besluit"
+      - type: "object"
+        properties:
           _links:
-            $ref: "#/components/schemas/Antwoord_links"
+            $ref: "#/components/schemas/Besluit_links"
     Besluit:
       type: "object"
-      description: "Een na overweging of beraadslaging vastgestelde beslissing voor\
-        \ een individueel of concreet geval. Een na overweging of beraadslaging vastgestelde\
-        \ beslissing voor een individueel of concreet geval. In het GFO Zaken kwam\
-        \ het objecttype BESCHIKKING voor. Aangezien dit een deelverzameling is van\
-        \ BESLUIT en er ook andere besluiten zijn dan beschikkingen, hanteren we hier\
-        \ de term ‘besluit’. Het gaat hierbij niet alleen om besluiten van bestuursorganen,\
-        \ inhoudende een publiekrechtelijke rechtshandeling, maar ook om andere besluiten,\
-        \ zoals bijvoorbeeld genomen op interne zaken. Een besluit wordt veelal schriftelijk\
-        \ vastgelegd maar dit is niet noodzakelijk. Omgekeerd kan het voorkomen dat\
-        \ in een INFORMATIEOBJECT meerdere besluiten vastgelegd zijn.Vandaar de N:M-relatie\
-        \ naar INFORMATIEOBJECT. Een besluit komt voort uit een zaak van de zaakbehandelende\
-        \ organisatie dan wel is een besluit van een andere organisatie dat het onderwerp\
-        \ (object) is van een zaak van de zaakbehandelende organisatie. BESLUIT heeft\
-        \ dan ook een optionele relatie met de ZAAK waarvan het een uitkomst is. Wel\
-        \ moet er minimaal een relatie naar ZAAK dan wel naar BESLUIT (ALS OBJECT)\
-        \ zijn. Indien een BESLUIT een beschikking betreft, is er sprake van een beschikkinghouder,\
-        \ bijvoorbeeld degene aan wie de vergunning verleend is. Dit is één van de\
-        \ betrokkkenen met een van toepassing zijnde rol bij de zaak waartoe het besluit\
-        \ behoort."
+      description: "<body>Een na overweging of beraadslaging vastgestelde beslissing\
+        \ voor een individueel of concreet geval.</body><body><p>Een na overweging\
+        \ of beraadslaging vastgestelde beslissing voor een individueel of concreet\
+        \ geval.</p></body><body></body>"
       required:
-      - "besluitdatum"
       - "besluitidentificatie"
-      - "ingangsdatum"
-      - "verantwoordelijkeOrganisatie"
+      - "toezegging"
       properties:
-        "@context":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@type":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-
-        besluitdatum:
-          type: "string"
-          title: "Besluitdatum"
-          description: "De beslisdatum (AWB) van het besluit. De beslisdatum (AWB)\
-            \ van het besluit. Het betreft de attribuutsoort Beschikkingsdatum in\
-            \ het GFO Zaken 2004. Alle geldige datums gelegen op of voor de huidige\
-            \ datum en tijd"
-          format: "date"
         besluitidentificatie:
           type: "string"
           title: "Besluitidentificatie"
-          description: "Identificatie van het besluit binnen de organisatie die het\
-            \ besluit heeft vastgesteld. Identificatie van het besluit binnen de organisatie\
-            \ die het besluit heeft vastgesteld. Het betreft de identificatie of ook\
-            \ wel nummer dat aan het besluit is toegekend door de organisatie die\
-            \ het besluit heeft vastgesteld. Dit identificeert een besluit uniek binnen\
-            \ de desbetreffende organisatie en kan worden gebruikt om snel te kunnen\
-            \ refereren aan een bepaald besluit in mondelinge en schriftelijke communicatie.\
-            \ Door combinatie met het RSIN van die organisatie, als waarde van de\
-            \ attribuutsoort ‘Verantwoordelijke organisatie’, wordt een unieke aanduiding\
-            \ van een besluit voor geheel Nederland verkregen. Het betreft de attribuutsoort\
-            \ Beschikkingidentificatie in het GFO Zaken 2004.organisatie. Er is immers\
-            \ maar één organisatie die de zaak gecreëerd heeft. Alle alfanumerieke\
-            \ tekens m.u.v. diacrieten"
+          description: "<body>Identificatie van het besluit binnen de organisatie\
+            \ die het besluit heeft vastgesteld.</body><body><p>Identificatie van\
+            \ het besluit binnen de organisatie die het besluit heeft vastgesteld.</p></body><body></body><body>Alle\
+            \ alfanumerieke tekens m.u.v. diacrieten</body>"
           maxLength: 50
           minLength: 1
+        besluitresultaat:
+          type: "string"
+          title: "Besluitresultaat"
+          description: "<body>Het resultaat van het BESLUIT</body><body>alle alfanumerieke\
+            \ tekens</body>"
+          maxLength: 200
         besluittoelichting:
           type: "string"
-          title: "Besluittoelichting"
-          description: "Toelichting bij het besluit. Toelichting bij het besluit.\
-            \ De (samenvatting van de) toelichting op het besluit zoals veelal vermeld\
-            \ in de besluittekst. Het betreft de attribuutsoort Beschikkingtoelichting\
-            \ in het GFO Zaken 2004. alle alfanumerieke tekens"
-          maxLength: 1000
-        bestuursorgaan:
+          title: "Besluitresultaat"
+          description: "<body>Het resultaat van het BESLUIT</body><body><p>Toelichting\
+            \ bij het besluit.</p></body><body>alle alfanumerieke tekens</body>"
+          maxLength: 200
+        toezegging:
           type: "string"
-          title: "Bestuursorgaan"
-          description: "Een orgaan van een rechtspersoon krachtens publiekrecht ingesteld\
-            \ of een persoon of college, met enig openbaar gezag bekleed onder wiens\
-            \ verantwoordelijkheid het besluit vastgesteld is. Een orgaan van een\
-            \ rechtspersoon krachtens publiekrecht ingesteld of een persoon of college,\
-            \ met enig openbaar gezag bekleed onder wiens verantwoordelijkheid het\
-            \ besluit vastgesteld is. Een orgaan van een rechtspersoon krachtens publiekrecht\
-            \ ingesteld of een persoon of college, met enig openbaar gezag bekleed\
-            \ onder wiens verantwoordelijkheid het besluit vastgesteld is. Het vastleggen\
-            \ van het bestuursorgaan onder wiens verantwoordelijkheid het besluit\
-            \ vastgesteld is, is vooral relevant indien de besluitvorming gemandateerd\
-            \ is aan een andere organisatie. Bijvoorbeeld een gemeente die de behandeling\
-            \ van milieuvergunningaanvragen heeft gemandateerd aan een Regionale UitvoeringsDienst\
-            \ (of Omgevingsdienst). Zie regels attribuutsoort"
-          maxLength: 50
-        ingangsdatum:
-          type: "string"
-          title: "Ingangsdatum"
-          description: "Ingangsdatum van de werkingsperiode van het besluit. Ingangsdatum\
-            \ van de werkingsperiode van het besluit. Het betreft de attribuutsoort\
-            \ Ingangsdatum (van BESCHIKKING) in het GFO Zaken 2004. Alle geldige datums\
-            \ zowel op, voor of na de huidige datum en tijd"
-          format: "date"
-        publicatiedatum:
-          type: "string"
-          title: "Publicatiedatum"
-          description: "Datum waarop het besluit gepubliceerd wordt. Datum waarop\
-            \ het besluit gepubliceerd wordt. Het betreft de attribuutsoort Publicatiedatum\
-            \ (van BESCHIKKING) in het GFO Zaken 2004. Alle geldige datums zowel op,\
-            \ voor of na de huidige datum en tijd"
-          format: "date"
-        uiterlijkeReactiedatum:
-          type: "string"
-          title: "Uiterlijke reactiedatum"
-          description: "De datum tot wanneer verweer tegen het besluit mogelijk is.\
-            \ De datum tot wanneer verweer tegen het besluit mogelijk is. De reactiedatum\
-            \ valt op zich af te leiden met behulp van andere attributen zoals Besluittype.Reactietermijn\
-            \ en Besluitdatum. De reactiedatum is hier als attribuutsoort opgenomen\
-            \ om deze datum expliciet te kunnen communiceren. Zodoende hoeven partijen\
-            \ niet telkens deze datum zelf af te leiden (rekening houdend met weekend-\
-            \ en feestdagen) en hoeven zij niet te beschikken over de desbetreffende\
-            \ besluittype-attributen. Alle geldige datums zowel op, voor of na de\
-            \ huidige datum en tijd"
-          format: "date"
-        verantwoordelijkeOrganisatie:
-          type: "integer"
-          title: "Verantwoordelijke organisatie"
-          description: "Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie\
-            \ die het besluit heeft vastgesteld. Het betreft het RSIN (Rechtspersonen\
-            \ en Samenwerkingsverbanden InformatieNummer) zoals dat door de KvK in\
-            \ het NHR aan elk rechtspersoon en samenwerkingsverband is toegekend.\
-            \ Dit identificeert uniek de organisatie, zijnde een rechtspersoon of\
-            \ samenwerkingsverband, die het besluit heeft vastgesteld. Dit zal veelal\
-            \ dezelfde organisatie zijn als vastgelegd bij de zaak in Verantwoordelijke\
-            \ organisatie. Het RSIN staat in het Handelsregister (NHR) en op het daaraan\
-            \ te ontlenen uittreksel. De in het NHR voorkomende unieke identificaties\
-            \ van rechtspersonen en samenwerkingsverbanden."
-          maximum: 9.99999999E8
-        vervaldatum:
-          type: "string"
-          title: "Vervaldatum"
-          description: "Datum waarop de werkingsperiode van het besluit eindigt. Datum\
-            \ waarop de werkingsperiode van het besluit eindigt. De werkingsperiode\
-            \ is inclusief de opgeven datum. Het betreft de attribuutsoort Vervaldatum\
-            \ (van BESCHIKKING) in het GFO Zaken 2004. Alle geldige datums zowel op,\
-            \ voor of na de huidige datum en tijd"
-          format: "date"
-        vervalreden:
-          $ref: "#/components/schemas/Vervalreden"
-        verzenddatum:
-          type: "string"
-          title: "Verzenddatum"
-          description: "Datum waarop het besluit verzonden is. Datum waarop het besluit\
-            \ verzonden is. Het betreft de attribuutsoort Verzenddatum (van BESCHIKKING)\
-            \ in het GFO Zaken 2004. Alle geldige datums zowel op, voor of na de huidige\
-            \ datum en tijd"
-          format: "date"
+          title: "Toezegging"
+          description: "<body>Bij een BESLUIT kan een additionele toezegging gedaan\
+            \ worden.</body>"
+          maxLength: 500
+          minLength: 1
+    BesluitvormingsstukHal:
+      allOf:
+      - $ref: "#/components/schemas/Besluitvormingsstuk"
+      - type: "object"
+        properties: {}
+    Besluitvormingsstuk:
+      allOf:
+      - $ref: "#/components/schemas/EnkelvoudigInformatieobject"
+      - type: "object"
+        description: "<body>Een BESLUITVORMINGSSTUK is een INFORMATIEOBJECT die als\
+          \ basis dient bij een STEMMING.</body>"
+        properties:
+          datumIngediend:
+            type: "string"
+            title: "Datum ingediend"
+            description: "<body>De datum waarop het BESLUITVORMINGSSTUK is ingediend</body>"
+            format: "date"
+          omschrijving:
+            type: "string"
+            title: "Omschrijving"
+            description: "<body>De omschrijving van het BESLUITVORMINGSSTUK</body><body>Dit\
+              \ kan de omschrijving zijn van de MOTIE, het AMENDEMENT of het VOORSTEL</body>"
+    BesluitvormingsstukHalCollectie:
+      type: "object"
+      properties:
         _links:
-          $ref: "#/components/schemas/Besluit_links"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+        _embedded:
+          type: "object"
+          properties:
+            besluitvormingsstukken:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/BesluitvormingsstukHal"
+    DagelijksBestuurHalCollectie:
+      type: "object"
+      properties:
+        _links:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+        _embedded:
+          type: "object"
+          properties:
+            dagelijksebesturen:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/DagelijksBestuurHal"
+    DagelijksBestuurHal:
+      allOf:
+      - $ref: "#/components/schemas/DagelijksBestuur"
+      - type: "object"
+        properties:
+          _links:
+            $ref: "#/components/schemas/DagelijksBestuur_links"
     DagelijksBestuur:
       type: "object"
-      description: "Het dagelijkse bestuur van de gemeente (college) of provincie\
-        \ (gedeputeerde staten) bereidt het beleid voor en voert dit beleid uit."
+      description: "<body>Het dagelijkse bestuur van de gemeente (college) of provincie\
+        \ (gedeputeerde staten) bereidt het beleid voor en voert dit beleid uit.</body>"
       required:
       - "dagelijksBestuurIdentificatie"
       - "dagelijksBestuurNaam"
       properties:
-        "@context":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@type":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
         dagelijksBestuurIdentificatie:
           type: "string"
           title: "dagelijksBestuurIdentificatie"
@@ -6152,101 +6618,126 @@ components:
         dagelijksBestuurNaam:
           type: "string"
           title: "Naam bestuurstype"
-          description: "De naam van het dagelijkse bestuur verschilt per bestuurslaag"
+          description: "<body>De naam van het dagelijkse bestuur verschilt per bestuurslaag</body>"
           maxLength: 200
           minLength: 1
+    DagelijksBestuurLidmaatschapHalCollectie:
+      type: "object"
+      properties:
         _links:
-          $ref: "#/components/schemas/DagelijksBestuur_links"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+        _embedded:
+          type: "object"
+          properties:
+            dagelijksbestuurlidmaatschappen:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/DagelijksBestuurLidmaatschapHal"
+    DagelijksBestuurLidmaatschapHal:
+      allOf:
+      - $ref: "#/components/schemas/DagelijksBestuurLidmaatschap"
+      - type: "object"
+        properties:
+          _links:
+            $ref: "#/components/schemas/DagelijksBestuurLidmaatschap_links"
     DagelijksBestuurLidmaatschap:
       type: "object"
-      description: "De lidmaatschap van het dagelijkse bestuur"
+      description: "<body>De lidmaatschap van het dagelijkse bestuur</body>"
       required:
-      - "collegelidmaatschapidentificatie"
+      - "dagelijksbestuurlidmaatschapidentificatie"
       properties:
-        "@context":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@type":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        collegelidmaatschapidentificatie:
+        dagelijksbestuurlidmaatschapidentificatie:
           type: "string"
-          title: "collegelidmaatschapidentificatie"
+          title: "dagelijksbestuurlidmaatschapidentificatie"
           description: ""
           maxLength: 10
           minLength: 1
         datumBeginCollegeLidmaatschap:
           type: "string"
           title: "Datum begin dagelijkse bestuur lidmaatschap"
-          description: "De datum en tijdstip waarop het lidmaatschap van het dagelijkse\
-            \ bestuur begon"
+          description: "<body>De datum en tijdstip waarop het lidmaatschap van het\
+            \ dagelijkse bestuur begon</body>"
         datumEindeCollegeLidmaatschap:
           type: "string"
           title: "Datum einde dagelijkse bestuur lidmaatschap"
-          description: "De datum en tijdstip waarop het lidmaatschap van het dagelijkse\
-            \ bestuur geëindigd is."
+          description: "<body>De datum en tijdstip waarop het lidmaatschap van het\
+            \ dagelijkse bestuur geÃ«indigd is.</body>"
+    FractieHalCollectie:
+      type: "object"
+      properties:
         _links:
-          $ref: "#/components/schemas/DagelijksBestuurLidmaatschap_links"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+        _embedded:
+          type: "object"
+          properties:
+            fracties:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/FractieHal"
+    FractieHal:
+      allOf:
+      - $ref: "#/components/schemas/Fractie"
+      - type: "object"
+        properties:
+          _links:
+            $ref: "#/components/schemas/Fractie_links"
     Fractie:
       type: "object"
-      description: "Is een deel van een gekozen volksvertegenwoordiging"
+      description: "<body>Is een deel van een gekozen volksvertegenwoordiging</body>"
       required:
       - "fractienaam"
       - "fractienummer"
       properties:
-        "@context":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@type":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
         fractienaam:
           type: "string"
           title: "Fractienaam"
-          description: "De naam van de fractie."
+          description: "<body>De naam van de fractie.</body>"
           maxLength: 100
           minLength: 1
         fractienummer:
           type: "string"
           title: "Fractienummer"
-          description: "Het nummer dat de FRACTIE uniek identificeert binnen de gemeente\
-            \ viercijferige gemeentecode gevolgd door een volgnummer van 7 cijfers\
-            \ met voorloopnullen"
+          description: "<body>Het nummer dat de FRACTIE uniek identificeert binnen\
+            \ de gemeente</body><body>viercijferige gemeentecode gevolgd door een\
+            \ volgnummer van 7 cijfers met voorloopnullen</body>"
           maxLength: 10
           minLength: 1
+    FractieLidmaatschapHalCollectie:
+      type: "object"
+      properties:
         _links:
-          $ref: "#/components/schemas/Fractie_links"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+        _embedded:
+          type: "object"
+          properties:
+            fractielidmaatschappen:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/FractieLidmaatschapHal"
+    FractieLidmaatschapHal:
+      allOf:
+      - $ref: "#/components/schemas/FractieLidmaatschap"
+      - type: "object"
+        properties:
+          _links:
+            $ref: "#/components/schemas/FractieLidmaatschap_links"
     FractieLidmaatschap:
       type: "object"
-      description: "De lidmaatschap van raadsleden en burgerleden van een fractie"
+      description: "<body>De lidmaatschap van raadsleden en burgerleden van een fractie</body>"
       required:
       - "fractieLidmaatschapIdentificatie"
       - "indicatieVoorzitter"
       properties:
-        "@context":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@type":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
         datumBeginFractieLidmaatschap:
           type: "string"
           title: "Datum begin fractie lidmaatschap"
-          description: "De datum en tijdstip waarop het fractie lidmaatschap begon"
+          description: "<body>De datum en tijdstip waarop het fractie lidmaatschap\
+            \ begon</body>"
         datumEindeFractieLidmaatschap:
           type: "string"
           title: "Datum einde fractie lidmaatschap"
-          description: "De datum en tijdstip waarop het fractie lidmaatschap geëindigd\
-            \ is."
+          description: "<body>De datum en tijdstip waarop het fractie lidmaatschap\
+            \ geÃ«indigd is.</body>"
         fractieLidmaatschapIdentificatie:
           type: "string"
           title: "fractieLidmaatschapIdentificatie"
@@ -6256,16 +6747,33 @@ components:
         indicatieVoorzitter:
           type: "boolean"
           title: "Indicatie voorzitter"
-          description: "Indicatie of iemand de voorzitter is van de FRACTIE Standaardwaarde\
-            \ is Nee"
+          description: "<body>Indicatie of iemand de voorzitter is van de FRACTIE</body><body>Standaardwaarde\
+            \ is Nee</body>"
+    IngekomenStukHalCollectie:
+      type: "object"
+      properties:
         _links:
-          $ref: "#/components/schemas/FractieLidmaatschap_links"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+        _embedded:
+          type: "object"
+          properties:
+            ingekomenstukken:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/IngekomenStukHal"
+    IngekomenStukHal:
+      allOf:
+      - $ref: "#/components/schemas/IngekomenStuk"
+      - type: "object"
+        properties:
+          _links:
+            $ref: "#/components/schemas/IngekomenStuk_links"
     IngekomenStuk:
       allOf:
       - $ref: "#/components/schemas/EnkelvoudigInformatieobject"
       - type: "object"
-        description: "Een ingekomen stuk is een stuk gericht aan de gemeenteraad,\
-          \ die voorafgaand aan de raadsbijeenkomst is ontvangen."
+        description: "<body>Een ingekomen stuk is een stuk gericht aan de gemeenteraad,\
+          \ die voorafgaand aan de raadsbijeenkomst is ontvangen.</body>"
         required:
         - "indicatieIngekomenstuk"
         properties:
@@ -6273,103 +6781,161 @@ components:
             type: "boolean"
             title: "indicatieIngekomenstuk"
             description: ""
+    MededelingHalCollectie:
+      type: "object"
+      properties:
+        _links:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+        _embedded:
+          type: "object"
+          properties:
+            mededelingen:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/MededelingHal"
+    MededelingHal:
+      allOf:
+      - $ref: "#/components/schemas/Mededeling"
+      - type: "object"
+        properties:
           _links:
-            $ref: "#/components/schemas/IngekomenStuk_links"
+            $ref: "#/components/schemas/Mededeling_links"
     Mededeling:
       allOf:
       - $ref: "#/components/schemas/EnkelvoudigInformatieobject"
       - type: "object"
-        description: "Een mededeling die gedaan wordt bij de vergadering Een mededeling\
-          \ die gedaan wordt bij de vergadering Een mededeling die gedaan wordt bij\
-          \ de vergadering Kan vaak een antwoord zijn op een toezegging."
+        description: "<body>Een mededeling die gedaan wordt bij de vergadering</body><body><p>Een\
+          \ mededeling die gedaan wordt bij de vergadering</p></body><body><p>Een\
+          \ mededeling die gedaan wordt bij de vergadering</p></body><body></body>"
         properties:
           mededelingomschrijving:
             type: "string"
             title: "Mededelingomschrijving"
-            description: "De omschrijving van de mededeling De omschrijving van de\
-              \ mededeling"
+            description: "<body>De omschrijving van de mededeling</body><body><p>De\
+              \ omschrijving van de mededeling</p></body>"
             example: "Dit is de tekst die in een mededeling zou kunnen worden opgenomen."
+    MotieHalCollectie:
+      type: "object"
+      properties:
+        _links:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+        _embedded:
+          type: "object"
+          properties:
+            Moties:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/MotieHal"
+    MotieHal:
+      allOf:
+      - $ref: "#/components/schemas/Motie"
+      - type: "object"
+        properties:
           _links:
-            $ref: "#/components/schemas/Mededeling_links"
+            $ref: "#/components/schemas/Motie_links"
+    Motie:
+      allOf:
+      - $ref: "#/components/schemas/Besluitvormingsstuk"
+      - type: "object"
+        description: "<body>Een MOTIE is een korte gemotiveerde verklaring over een\
+          \ onderwerp waardoor een mening, wens of verzoek wordt uitgesproken en is\
+          \ ingediend door een raadslid of een statenlid.</body><body>Een motie begint\
+          \ met de reden van indiening en eindigt met de uitspraak. Een motie is juridisch\
+          \ niet bindend en wordt eerst ter stemming voorgelegd tijdens de VERGADERING\
+          \ van de gemeenteraad of provinciale staten. Een motie kan zelfstandig zijn\
+          \ of gekoppeld aan een voorstel dat ter bespreking voorligt.</body>"
+        properties:
+          motietype:
+            $ref: "#/components/schemas/MotieType"
+    NatuurlijkPersoonHalCollectie:
+      type: "object"
+      properties:
+        _links:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+        _embedded:
+          type: "object"
+          properties:
+            natuurlijkpersonen:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/NatuurlijkPersoonHal"
+    NatuurlijkPersoonHal:
+      allOf:
+      - $ref: "#/components/schemas/NatuurlijkPersoon"
+      - type: "object"
+        properties:
+          _links:
+            $ref: "#/components/schemas/NatuurlijkPersoon_links"
     NatuurlijkPersoon:
       type: "object"
-      description: "Een PERSOON zijnde een mens. Een PERSOON zijnde een mens. Het\
-        \ betreft de verzameling van personen, ingeschreven in de BasisRegistratie\
-        \ Personen (GBA en RNI), woonachtig in de gemeente dan wel elders en van belang\
-        \ voor de gemeentelijke taakuitoefening (ingezetenen) alsmede andere personen,\
-        \ woonachtig in het binnen- of buitenland, niet ingeschreven in de GBA maar\
-        \ wel van belang voor de gemeentelijke taakuitoefening zoals buitenlanders\
-        \ die bijvoorbeeld belastingplichtig zijn voor een gemeentelijke belasting.\
-        \ NATUURLIJK PERSOON is een specialisatie van PERSOON."
+      description: "<body>Een PERSOON zijnde een mens.</body>"
       required:
-      - "nummerNatuurlijkPersoon"
       - "naamNatuurlijkPersoon"
+      - "nummerNatuurlijkPersoon"
       properties:
-        "@context":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@type":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
         functie:
           $ref: "#/components/schemas/Functie"
         geslachtsaanduiding:
           $ref: "#/components/schemas/Geslacht"
-        nummerNatuurlijkPersoon:
-          type: "string"
-          title: "Nummer natuurlijk persoon"
-          description: "Het identificerende nummer van een NATUURLIJK PERSOON niet\
-            \ zijnde het burgerservicenummer Het kan dus voorkomen dat dezelfde natuurlijke\
-            \ persoon bij twee of meer gemeenten geregistreerd is onder een ander\
-            \ nummer. viercijferige gemeentecode gevolgd door een volgnummer van 13\
-            \ cijfers met voorloopnullen"
-          maxLength: 17
-          minLength: 1
         naamNatuurlijkPersoon:
           $ref: "#/components/schemas/NaamNatuurlijkPersoon"
         nevenFunctieNatuurlijkPersoon:
           type: "array"
           items:
             $ref: "#/components/schemas/NevenfunctieNatuurlijkePersoon"
+        nummerNatuurlijkPersoon:
+          type: "string"
+          title: "Nummer natuurlijk persoon"
+          description: "<body>Het identificerende nummer van een NATUURLIJK PERSOON\
+            \ niet zijnde het burgerservicenummer</body><body>Het kan dus voorkomen\
+            \ dat dezelfde natuurlijke persoon bij twee of meer gemeenten geregistreerd\
+            \ is onder een ander nummer.</body><body>viercijferige gemeentecode gevolgd\
+            \ door een volgnummer van 13 cijfers met voorloopnullen</body>"
+          maxLength: 17
+          minLength: 1
+    SpreekfragmentHalCollectie:
+      type: "object"
+      properties:
         _links:
-          $ref: "#/components/schemas/NatuurlijkPersoon_links"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+        _embedded:
+          type: "object"
+          properties:
+            spreekfragmenten:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/SpreekfragmentHal"
+    SpreekfragmentHal:
+      allOf:
+      - $ref: "#/components/schemas/Spreekfragment"
+      - type: "object"
+        properties:
+          _links:
+            $ref: "#/components/schemas/Spreekfragment_links"
     Spreekfragment:
       type: "object"
-      description: "Een AANWEZIGEDEELNEMER spreekt tijdens een AGENDAPUNT"
+      description: "<body>Een AANWEZIGE DEELNEMER spreekt tijdens een AGENDAPUNT</body>"
       required:
       - "spreekfragmentidentificatie"
       properties:
-        "@context":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@type":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
         aanvangSpreekfragment:
           type: "string"
           title: "Aanvang spreekfragment"
-          description: "De tijdstip en datum van aanvang van het SPREEKFRAGMENT"
+          description: "<body>De tijdstip en datum van aanvang van het SPREEKFRAGMENT</body>"
         audioLink:
           type: "string"
           title: "Taal"
-          description: "De taal van het SPREEKFRAGMENT"
+          description: "<body>De taal van het SPREEKFRAGMENT</body>"
           format: "uri"
         audioTijdsaanduiding:
           type: "integer"
           title: "Audio tijdsaanduiding"
-          description: "De tijdsaanduiding naar de audio opname van het SPREEKFRAGMENT\
-            \ hh:mm:ss"
+          description: "<body>De tijdsaanduiding naar de audio opname van het SPREEKFRAGMENT</body><body>hh:mm:ss</body>"
           maximum: 999999
         positieNotulen:
           type: "string"
           title: "Positie notulen"
-          description: "De positie van het SPREEKFRAGMENT binnen de notulen"
+          description: "<body>De positie van het SPREEKFRAGMENT binnen de notulen</body>"
           maxLength: 10
         spreekfragmentidentificatie:
           type: "string"
@@ -6380,48 +6946,55 @@ components:
         taal:
           type: "string"
           title: "Taal"
-          description: "De taal van het SPREEKFRAGMENT"
+          description: "<body>De taal van het SPREEKFRAGMENT</body>"
           maxLength: 20
         tekstSpreekfragment:
           type: "string"
           title: "Tekst spreekfragment"
-          description: "De uitgeschreven weergave van het SPREEKFRAGMENT"
+          description: "<body>De uitgeschreven weergave van het SPREEKFRAGMENT</body>"
         titelSpreekfragment:
           type: "string"
           title: "Titel spreekfragment"
-          description: "De titel die kenmerkend is voor het SPREEKFRAGMENT of deel\
-            \ van de discussie"
+          description: "<body>De titel die kenmerkend is voor het SPREEKFRAGMENT of\
+            \ deel van de discussie</body>"
           maxLength: 100
         videoLink:
           type: "string"
           title: "Video link"
-          description: "De link naar de video opname van het SPREEKFRAGMENT"
+          description: "<body>De link naar de video opname van het SPREEKFRAGMENT</body>"
           format: "uri"
         videoTijdsaanduiding:
           type: "integer"
           title: "Video tijdsaanduiding"
-          description: "De tijdsaanduiding naar de video opname van het SPREEKFRAGMENT\
-            \ hh:mm:ss"
+          description: "<body>De tijdsaanduiding naar de video opname van het SPREEKFRAGMENT</body><body>hh:mm:ss</body>"
           maximum: 999999
+    StemHalCollectie:
+      type: "object"
+      properties:
         _links:
-          $ref: "#/components/schemas/Spreekfragment_links"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+        _embedded:
+          type: "object"
+          properties:
+            stemmen:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/StemHal"
+    StemHal:
+      allOf:
+      - $ref: "#/components/schemas/Stem"
+      - type: "object"
+        properties:
+          _links:
+            $ref: "#/components/schemas/Stem_links"
     Stem:
       type: "object"
-      description: "Een STEM is een formele uitdrukking van een keuze die een raadslid\
-        \ (gemeente) of statenlid (provincie) maakt over een bepaald onderwerp."
+      description: "<body>Een STEM is een formele uitdrukking van een keuze die een\
+        \ raadslid (gemeente) of statenlid (provincie) maakt over een bepaald onderwerp.</body>"
       required:
       - "keuzeMondelingeStemming"
       - "stemIdentificatie"
       properties:
-        "@context":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@type":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
         keuzeMondelingeStemming:
           $ref: "#/components/schemas/StemKeuze"
         stemIdentificatie:
@@ -6430,64 +7003,82 @@ components:
           description: ""
           maxLength: 10
           minLength: 1
+    StemmingHalCollectie:
+      type: "object"
+      properties:
         _links:
-          $ref: "#/components/schemas/Stem_links"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+        _embedded:
+          type: "object"
+          properties:
+            stemmingen:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/StemmingHal"
+    StemmingHal:
+      allOf:
+      - $ref: "#/components/schemas/Stemming"
+      - type: "object"
+        properties:
+          _links:
+            $ref: "#/components/schemas/Stemming_links"
     Stemming:
       type: "object"
-      description: "Een moment waarop een keuze gemaakt moet worden over een bepaald\
-        \ AGENDAPUNT of VERGADERSTUK, waarbij alle uitgebrachte stemmen geteld worden.\
-        \ Alleen aanwezige raadsleden (gemeente) of statenleden (provincie) kunnen\
-        \ een stem uitbrengen."
+      description: "<body>Een moment waarop een keuze gemaakt moet worden over een\
+        \ bepaald AGENDAPUNT of VERGADERSTUK, waarbij alle uitgebrachte stemmen geteld\
+        \ worden.</body><body>Alleen aanwezige raadsleden (gemeente) of statenleden\
+        \ (provincie) kunnen een stem uitbrengen.</body>"
       required:
       - "stemmingsidentificatie"
       properties:
-        "@context":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@type":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
         resultaatMondelingeStemming:
           $ref: "#/components/schemas/StemmingResultaat"
         resultaatStemmingOverPersonen:
           type: "string"
           title: "'Resultaat stemming over personen"
-          description: "Het resultaat van de stemming over één of meerdere personen."
+          description: "<body>Het resultaat van de stemming over Ã©Ã©n of meerdere\
+            \ personen.</body>"
           maxLength: 200
-        stemmingsidentificatie:
-          type: "string"
-          title: "Stemmingsidentificatie"
-          description: "De identificatie van de STEMMING De eerste vier karakter zijn\
-            \ de gemeentecode, gevolgd door een volgnummer van 7 cijfers met voorloopnullen"
-          maxLength: 10
-          minLength: 1
-        stemmingstype:
-          $ref: "#/components/schemas/StemmingsType"
         stemmingOverPersonen:
           type: "array"
           items:
             $ref: "#/components/schemas/StemmingOverPersonen"
+        stemmingsidentificatie:
+          type: "string"
+          title: "Stemmingsidentificatie"
+          description: "<body>De identificatie van de STEMMING</body><body>De eerste\
+            \ vier karakter zijn de gemeentecode, gevolgd door een volgnummer van\
+            \ 7 cijfers met voorloopnullen</body>"
+          maxLength: 10
+          minLength: 1
+        stemmingstype:
+          $ref: "#/components/schemas/StemmingsType"
+    StemresultaatPerFractieHalCollectie:
+      type: "object"
+      properties:
         _links:
-          $ref: "#/components/schemas/Stemming_links"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+        _embedded:
+          type: "object"
+          properties:
+            stemresultatenperfractie:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/StemresultaatPerFractieHal"
+    StemresultaatPerFractieHal:
+      allOf:
+      - $ref: "#/components/schemas/StemresultaatPerFractie"
+      - type: "object"
+        properties:
+          _links:
+            $ref: "#/components/schemas/StemresultaatPerFractie_links"
     StemresultaatPerFractie:
       type: "object"
-      description: "Het resultaat van de STEMMING per FRACTIE en wordt afgeleid van\
-        \ de uitgebrachte STEMmen."
+      description: "<body>Het resultaat van de STEMMING per FRACTIE en wordt afgeleid\
+        \ van de uitgebrachte STEMmen.</body>"
       required:
       - "stemresultaatperfractieidentificatie"
       properties:
-        "@context":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@type":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
         fractiestemresultaat:
           $ref: "#/components/schemas/FractieStemResultaat"
         stemresultaatperfractieidentificatie:
@@ -6496,129 +7087,220 @@ components:
           description: ""
           maxLength: 10
           minLength: 1
+    ToezeggingHalCollectie:
+      type: "object"
+      properties:
         _links:
-          $ref: "#/components/schemas/StemresultaatPerFractie_links"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+        _embedded:
+          type: "object"
+          properties:
+            toezeggingen:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/ToezeggingHal"
+    ToezeggingHal:
+      allOf:
+      - $ref: "#/components/schemas/Toezegging"
+      - type: "object"
+        properties:
+          _links:
+            $ref: "#/components/schemas/Toezegging_links"
     Toezegging:
       allOf:
       - $ref: "#/components/schemas/EnkelvoudigInformatieobject"
       - type: "object"
-        description: "Een toezegging van een gedeputeerde of raadslid Een toezegging\
-          \ van een gedeputeerde of raadslid Een toezegging van een gedeputeerde of\
-          \ raadslid"
+        description: "<body>Een toezegging van een gedeputeerde of raadslid</body><body><p>Een\
+          \ toezegging van een gedeputeerde of raadslid</p></body><body><p>Een toezegging\
+          \ van een gedeputeerde of raadslid</p></body>"
         required:
         - "toezeggingsomschrijving"
         properties:
           toezeggingsomschrijving:
             type: "string"
             title: "Toezeggingsomschrijving"
-            description: "De omschrijving van een toezegging De omschrijving van een\
-              \ toezegging"
+            description: "<body>De omschrijving van een toezegging</body><body><p>De\
+              \ omschrijving van een toezegging</p></body>"
             minLength: 1
+    VergaderingHalCollectie:
+      type: "object"
+      properties:
+        _links:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+        _embedded:
+          type: "object"
+          properties:
+            vergaderingen:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/VergaderingHal"
+    VergaderingHal:
+      allOf:
+      - $ref: "#/components/schemas/Vergadering"
+      - type: "object"
+        properties:
           _links:
-            $ref: "#/components/schemas/Toezegging_links"
+            $ref: "#/components/schemas/Vergadering_links"
     Vergadering:
       type: "object"
-      description: "Een VERGADERING is een bijeenkomst van meerdere mensen die met\
-        \ elkaar spreken en/of afspraken maken over onderwerpen die op de agenda staan."
+      description: "<body>Een VERGADERING is een bijeenkomst van meerdere mensen die\
+        \ met elkaar spreken en/of afspraken maken over onderwerpen die op de agenda\
+        \ staan.</body>"
       required:
       - "vergaderingsidentificatie"
       - "vergaderingstype"
       properties:
-        "@context":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@type":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
         aanvangVergadering:
           type: "string"
           title: "Aanvang vergadering"
-          description: "De datum en tijdstip waarop de vergadering is gestart Komt\
-            \ zeker voor als Einde vergadering ook is ingevuld"
+          description: "<body>De datum en tijdstip waarop de vergadering is gestart</body><body>Komt\
+            \ zeker voor als Einde vergadering ook is ingevuld</body>"
           example: "2017-02-10T18:25:00:000Z"
         audioLink:
           type: "string"
           title: "Audio link"
-          description: "De link naar de audio opname van de VERGADERING"
+          description: "<body>De link naar de audio opname van de VERGADERING</body>"
           format: "uri"
           example: "https://www.voorbeeldgemeente.nl/audio/link"
         eindeVergadering:
           type: "string"
           title: "Einde vergadering"
-          description: "De datum en tijdstip waarop de vergadering is geëindigd"
+          description: "<body>De datum en tijdstip waarop de vergadering is geÃ«indigd</body>"
           example: "2017-02-10T21:12:00:000Z"
+        georganiseerdDoorGremium:
+          allOf:
+          - $ref: "#/components/schemas/Gremium"
+          - title: "georganiseerdDoorGremium"
+            description: "<body>de vergadering is georganiseerd door een gremium</body>"
         geplandeAanvangVergadering:
           type: "string"
           title: "Geplande aanvang vergadering"
-          description: "De geplande datum en tijdstip waarop de vergadering start"
+          description: "<body>De geplande datum en tijdstip waarop de vergadering\
+            \ start</body>"
           example: "2017-02-09T18:25:00:000Z"
         geplandeEindeVergadering:
           type: "string"
           title: "Geplande einde vergadering"
-          description: "De geplande datum en tijdstip waarop de vergadering eindigt"
+          description: "<body>De geplande datum en tijdstip waarop de vergadering\
+            \ eindigt</body>"
           example: "2017-02-09T21:25:00:000Z"
         geplandeVergaderdatum:
           type: "string"
           title: "Geplande vergaderdatum"
-          description: "De geplande datum van de VERGADERING"
+          description: "<body>De geplande datum van de VERGADERING</body>"
           format: "date"
           example: "2017-02-09"
         locatie:
           type: "string"
           title: "Locatie"
-          description: "Omschrijving van de locatie waar de vergadering wordt gehouden"
+          description: "<body>Omschrijving van de locatie waar de vergadering wordt\
+            \ gehouden</body>"
           maxLength: 100
           example: "Raadszaal, Stadskantoor, Overtoom 2"
         naam:
           type: "string"
           title: "Naam"
-          description: "De naam van de vergadering"
+          description: "<body>De naam van de vergadering</body>"
           maxLength: 100
           example: "Raadsvergadering"
         status:
           $ref: "#/components/schemas/VergaderingStatus"
+        vergaderToelichting:
+          type: "string"
+          title: "Vergader toelichting"
+          description: "<body>De toelichting of nadere omschrijving van de vergadering</body>"
+          example: "Regulier geplande raadsvergadering van mei"
         vergaderdatum:
           type: "string"
           title: "Vergaderdatum"
-          description: "De datum van de VERGADERING"
+          description: "<body>De datum van de VERGADERING</body>"
           format: "date"
           example: "2017-02-10"
         vergaderingsidentificatie:
           type: "string"
           title: "Vergaderingsidentificatie"
-          description: "De identificatie een VERGADERING De eerste vier karakter zijn\
-            \ de gemeentecode, gevolgd door een volgnummer van 7 cijfers met voorloopnullen."
+          description: "<body>De identificatie een VERGADERING</body><body>De eerste\
+            \ vier karakter zijn de gemeentecode, gevolgd door een volgnummer van\
+            \ 7 cijfers met voorloopnullen.</body>"
           maxLength: 10
           minLength: 1
           example: "1234567890"
         vergaderingstype:
           $ref: "#/components/schemas/VergaderingsType"
-        vergaderToelichting:
-          type: "string"
-          title: "Vergader toelichting"
-          description: "De toelichting of nadere omschrijving van de vergadering"
-          example: "Regulier geplande raadsvergadering van mei"
         videoLink:
           type: "string"
           title: "Video link"
-          description: "De link naar de video opname van de VERGADERING"
+          description: "<body>De link naar de video opname van de VERGADERING</body>"
           format: "uri"
           example: "https://www.voorbeeldgemeente.nl/video/link"
-        georganiseerdDoorGremium:
-          $ref: "#/components/schemas/Gremium"
+    VoorstelHalCollectie:
+      type: "object"
+      properties:
         _links:
-          $ref: "#/components/schemas/Vergadering_links"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+        _embedded:
+          type: "object"
+          properties:
+            voorstellen:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/VoorstelHal"
+    VoorstelHal:
+      allOf:
+      - $ref: "#/components/schemas/Voorstel"
+      - type: "object"
+        properties:
+          _links:
+            $ref: "#/components/schemas/Voorstel_links"
+    Voorstel:
+      allOf:
+      - $ref: "#/components/schemas/Besluitvormingsstuk"
+      - type: "object"
+        description: "<body>Een VOORSTEL is een plan waarover een BESLUIT genomen\
+          \ kan worden d.m.v. een STEMMING.</body><body>Het college van B&W (gemeente)\
+          \ of de gedeputeerde staten (provincie) bereiden de meeste VOORSTELlen voor.\
+          \ Het VOORSTEL en eventuele AMENDEMENTen en inhoudelijke stukken beschrijven\
+          \ het VOORSTEL in detail. Vaak worden de VOORSTELlen eerst besproken in\
+          \ een meningsvormende ronde of in Ã©Ã©n van de (raads/staten)commissies.\
+          \ Er wordt gekeken of er voldoende informatie is om in de volgende besluitvormende\
+          \ VERGADERING van de gemeenteraad of gedeptueerde staten over dat voorstel\
+          \ een BESLUIT te nemen. In de besluitvormende vergadering wordt door de\
+          \ raadsleden of statenleden 'voor' of 'tegen' het VOORSTEL gestemd. Is de\
+          \ meerderheid 'voor' dan is het VOORSTEL aangenomen. Is de meerderheid 'tegen'\
+          \ dan is het VOORSTEL verworpen.</body>"
+        properties:
+          portefeuillehouder:
+            type: "string"
+            title: "Antwoordomschrijving"
+            description: "<body>De omschrijving van het antwoord</body>"
+            maxLength: 100
+    VraagHalCollectie:
+      type: "object"
+      properties:
+        _links:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+        _embedded:
+          type: "object"
+          properties:
+            vragen:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/VraagHal"
+    VraagHal:
+      allOf:
+      - $ref: "#/components/schemas/Vraag"
+      - type: "object"
+        properties:
+          _links:
+            $ref: "#/components/schemas/Vraag_links"
     Vraag:
       allOf:
       - $ref: "#/components/schemas/EnkelvoudigInformatieobject"
       - type: "object"
-        description: "Dit zijn vragen die raadsleden aan het college of de burgemeester\
+        description: "<body>Dit zijn vragen die raadsleden aan het college of de burgemeester\
           \ stellen (gemeente) of die statenleden aan de gedeputeerde staten of de\
-          \ commissaris stellen (provincie). Dit kunnen zowel schriftelijke vragen\
-          \ zijn als vragen die gesteld worden bij bijvoorbeeld het vragenuur."
+          \ commissaris stellen (provincie).</body><body>Dit kunnen zowel schriftelijke\
+          \ vragen zijn als vragen die gesteld worden bij bijvoorbeeld het vragenuur.</body>"
         required:
         - "typeVraag"
         properties:
@@ -6627,258 +7309,84 @@ components:
           vraagomschrijving:
             type: "string"
             title: "Vraagomschrijving"
-            description: "De omschrijving van de vraag"
-          _links:
-            $ref: "#/components/schemas/Vraag_links"
-    NaamNatuurlijkPersoon:
-      type: "object"
-      description: "De naam van een NATUURLIJK PERSOON"
-      required:
-      - "achternaam"
-      properties:
-        achternaam:
-          type: "string"
-          title: "Achternaam"
-          description: "De achternaam van een NATUURLIJK PERSOON"
-          maxLength: 200
-          minLength: 1
-        tussenvoegsel:
-          type: "string"
-          title: "Tussenvoegsel"
-          description: "De tussenvoegsel van een NATUURLIJK PERSOON"
-          maxLength: 20
-        voorletters:
-          type: "string"
-          title: "Voorletters"
-          description: "De voorletters van een NATUURLIJK PERSOON"
-          maxLength: 20
-        voornamen:
-          type: "string"
-          title: "Voornamen"
-          description: "De voornamen van een NATUURLIJK PERSOON."
-          maxLength: 200
-    NevenfunctieNatuurlijkePersoon:
-      type: "object"
-      description: "De nevenfuncties van een NATUURLIJKE PERSOON"
-      required:
-      - "datumAanvangNevenfunctie"
-      - "indicatorBezoldigd"
-      - "omschrijvingNevenfuctie"
-      properties:
-        aantalUrenPerMaand:
-          type: "integer"
-          title: "Aantal uren per maand"
-          description: "Het aantal uren dat per maand besteed wordt aan de nevenfunctie"
-          maximum: 999
-        datumAanvangNevenfunctie:
-          type: "string"
-          title: "Datum aanvang nevenfunctie"
-          description: "De datum van aanvang van de nevenfunctie"
-          format: "date"
-        datumEindeNevenfunctie:
-          type: "string"
-          title: "Datum einde nevenfunctie"
-          description: "De datum van het einde van de nevenfunctie"
-          format: "date"
-        datumMelding:
-          type: "string"
-          title: "Datum melding"
-          description: "De datum waarop de nevenfunctie gemeld is bij de griffie."
-          format: "date"
-        indicatorBezoldigd:
-          type: "boolean"
-          title: "Indicator bezoldigd"
-          description: "Indicator of de nevenfunctie uitgevoerd wordt tegen betaling."
-        indicatorInFunctieVanLidmaatschap:
-          type: "boolean"
-          title: "Indicator nevenfunctie vanwege lidmaatschap"
-          description: "Indicator die aangeeft of de nevenfunctie wordt vervuld vanwege\
-            \ de lidmaatschap van de Raad of de Staten."
-        naamOrganisatieNevenfunctie:
-          type: "string"
-          title: "Naam organisatie nevenfunctie"
-          description: "De naam van de organisatie van de nevenfunctie"
-          maxLength: 100
-        omschrijvingNevenfuctie:
-          type: "string"
-          title: "Omschrijving nevenfunctie"
-          description: "De omschrijving van de nevenfunctie."
-          maxLength: 100
-          minLength: 1
-    StemmingOverPersonen:
-      type: "object"
-      description: "De uitslag van de stemming over personen De individuele uitgebrachte\
-        \ STEMmen over personen zijn geheim. Alleen het aantal uitgebrachte stemmen\
-        \ per kandidaat is bekend."
-      required:
-      - "aantalUitgebrachteStemmen"
-      - "naamKandidaat"
-      properties:
-        aantalUitgebrachteStemmen:
-          type: "integer"
-          title: "Aantal uitgebrachte stemmen"
-          description: "Het aantal uitgebracht stemmen behorend bij een kandidaat"
-          maximum: 999
-        naamKandidaat:
-          type: "string"
-          title: "Naam kandidaat"
-          description: "De naam van de kandidaat over wie gestemd is"
-          maxLength: 100
-          minLength: 1
-    Gremium:
-      type: "object"
-      description: "De referentielijst met alle gremia in een gemeente De referentielijst\
-        \ met alle gremia in een gemeente Hier horen ook alle commissies bij van de\
-        \ gemeenteraad"
-      required:
-      - "gremiumidentificatie"
-      - "gremiumNaam"
-      properties:
-        "@context":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@type":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        gremiumidentificatie:
-          type: "string"
-          title: "gremiumidentificatie"
-          description: "De identificatie van een gremium De eerste vier karakter zijn\
-            \ de gemeentecode, gevolgd door een volgnummer van 7 cijfers met voorloopnullen."
-          maxLength: 10
-          minLength: 1
-        gremiumNaam:
-          type: "string"
-          title: "Gremium naam"
-          description: "De naam van het gremium De naam van het gremium Hier horen\
-            \ ook de (raads- en staten)commissies bij"
-          maxLength: 100
-          minLength: 1
-    Besluitvormingsstuk:
-      allOf:
-      - $ref: "#/components/schemas/EnkelvoudigInformatieobject"
-      - type: "object"
-        description: "Een BESLUITVORMINGSSTUK is een INFORMATIEOBJECT die als basis\
-          \ dient bij een STEMMING."
-        properties:
-          datumIngediend:
-            type: "string"
-            title: "Datum ingediend"
-            description: "De datum waarop het BESLUITVORMINGSSTUK is ingediend"
-            format: "date"
-          omschrijving:
-            type: "string"
-            title: "Omschrijving"
-            description: "De omschrijving van het BESLUITVORMINGSSTUK Dit kan de omschrijving\
-              \ zijn van de MOTIE, het AMENDEMENT of het VOORSTEL"
+            description: "<body>De omschrijving van de vraag</body>"
     EnkelvoudigInformatieobject:
       allOf:
       - $ref: "#/components/schemas/Informatieobject"
       - type: "object"
-        description: "Een INFORMATIEOBJECT waarvan aard, omvang en/of vorm aanleiding\
-          \ geven het als één geheel te behandelen en te beheren. Een ENKELVOUDIG\
-          \ INFORMATIEOBJECT is een specialisatie van INFORMATIEOBJECT. Zie de toelichting\
-          \ bij dat objecttype. Bij de definitie is gebruik gemaakt van de beschrijving\
-          \ van 'component' in de MoReq2 (2008). In de dagelijkse praktijk staat 'ENKELVOUDIG\
-          \ INFORMATIEOBJECT' veelal synoniem met 'document'. Het ENKELVOUDIG INFORMATIEOBJECT\
-          \ kan deel uit maken van een SAMENGESTELD INFORMATIEOBJECT, bijvoorbeeld\
-          \ omdat zich in dat SAMENGESTELD INFORMATIEOBJECT andere documenten bevinden\
-          \ met een ander bestandsformaat, vanwege de omvang van dat SAMENGESTELD\
-          \ INFORMATIEOBJECT of omdat behandeling daartoe aanleiding geeft. Een ENKELVOUDIG\
-          \ INFORMATIEOBJECT dat deel uit maakt van een SAMENGESTELD INFORMATIEOBJECT\
-          \ kan aan andere ZAAKen gerelateerd zijn dan de ZAAK waaraan dat SAMENGESTELD\
-          \ INFORMATIEOBJECT gerelateerd is, veelal omdat dat ENKELVOUDIG INFORMATIEOBJECT\
-          \ relevant is voor meerdere ZAAKen. INFORMATIEOBJECTen, vooral die van de\
-          \ zaakbehandelende organisatie, worden soms gewijzigd of in opeenvolgende\
-          \ conceptversies vervaardigd. Het is uit oogpunt van verantwoording van\
-          \ belang de diverse informatieobjectversies te kennen. Hiertoe is bij de\
-          \ meeste van de attribuuttypen van ENKELVOUDIG INFORMATIEOBJECT zowel materië\
-          le als formele historie als ‘Ja’ gedeclareerd. Dit impliceert dat voor deze\
-          \ attributen de waarden in de diverse versies van een ENKELVOUDIG INFORMATIEOBJECT\
-          \ opgevraagd kunnen worden."
+        description: "<body>Een INFORMATIEOBJECT waarvan aard, omvang en/of vorm aanleiding\
+          \ geven het als Ã©Ã©n geheel te behandelen en te beheren.</body><body>Een\
+          \ ENKELVOUDIG INFORMATIEOBJECT is een specialisatie van INFORMATIEOBJECT.\
+          \ Zie de toelichting bij dat objecttype. Bij de definitie is gebruik gemaakt\
+          \ van de beschrijving van 'component' in de MoReq2 (2008). In de dagelijkse\
+          \ praktijk staat 'ENKELVOUDIG INFORMATIEOBJECT' veelal synoniem met 'document'.\
+          \ Het ENKELVOUDIG INFORMATIEOBJECT kan deel uit maken van een SAMENGESTELD\
+          \ INFORMATIEOBJECT, bijvoorbeeld omdat zich in dat SAMENGESTELD INFORMATIEOBJECT\
+          \ andere documenten bevinden met een ander bestandsformaat, vanwege de omvang\
+          \ van dat SAMENGESTELD INFORMATIEOBJECT of omdat behandeling daartoe aanleiding\
+          \ geeft. Een ENKELVOUDIG INFORMATIEOBJECT dat deel uit maakt van een SAMENGESTELD\
+          \ INFORMATIEOBJECT kan aan andere ZAAKen gerelateerd zijn dan de ZAAK waaraan\
+          \ dat SAMENGESTELD INFORMATIEOBJECT gerelateerd is, veelal omdat dat ENKELVOUDIG\
+          \ INFORMATIEOBJECT relevant is voor meerdere ZAAKen. INFORMATIEOBJECTen,\
+          \ vooral die van de zaakbehandelende organisatie, worden soms gewijzigd\
+          \ of in opeenvolgende conceptversies vervaardigd. Het is uit oogpunt van\
+          \ verantwoording van belang de diverse informatieobjectversies te kennen.\
+          \ Hiertoe is bij de meeste van de attribuuttypen van ENKELVOUDIG INFORMATIEOBJECT\
+          \ zowel materiÃ«le als formele historie als â€˜Jaâ€™ gedeclareerd. Dit impliceert\
+          \ dat voor deze attributen de waarden in de diverse versies van een ENKELVOUDIG\
+          \ INFORMATIEOBJECT opgevraagd kunnen worden.</body>"
         required:
-        - "formaat"
         - "taal"
         properties:
-          bestandsomvang:
-            type: "integer"
-            title: "Bestandsomvang"
-            description: "Ruimtebeslag op het digitale opslagmedium waarin het fysieke\
-              \ bestand met de inhoud van het INFORMATIEOBJECT is vastgelegd Ofschoon\
-              \ dit een afleidbaar gegeven is, aangezien het af te leiden is uit het\
-              \ fysieke bestand, is er voor gekozen dit gegeven toch op te nemen.\
-              \ Het kunnen afleiden van dit gegeven veronderstelt dat het bestand\
-              \ zelf beschikbaar is om dit gegeven af te kunnen leiden en dat functionaliteiten\
-              \ hiervoor beschikbaar zijn. Hiervan is niet altijd sprake. Omvang van\
-              \ het fysieke bestand in aantal bytes."
-            maximum: 9.999999999E9
-          formaat:
-            type: "string"
-            title: "Formaat"
-            description: "De code voor de wijze waarop de inhoud van het ENKELVOUDIG\
-              \ INFORMATIEOBJECT is vastgelegd in een computerbestand. Het gaat hier\
-              \ om de bestandsoort van het enkelvoudig informatieobject. Het betreft\
-              \ het Dublin Core metadata-element ‘Format’ met als toelichting: Typically,\
-              \ Format will include the media-type or dimensions of the resource.\
-              \ Format may be used to identify the software, hardware, or other equipment\
-              \ needed to display or operate the resource. Examples of dimensions\
-              \ include size and duration. Recommended best practice is to select\
-              \ a value from a controlled vocabulary (for example, the list of Internet\
-              \ Media Types (MIME) defining computer media formats). Aangezien, bij\
-              \ bijvoorbeeld omzetting naar een duurzaam bewaarbaar informatieobject,\
-              \ het formaat kan wijzigen kent deze attribuutsoort historie. MIME-types\
-              \ en –subtypes conform IANA"
-            minLength: 1
           inhoud:
             type: "string"
             title: "Inhoud"
-            description: "Datgene wat in een ENKELVOUDIG INFORMATIEOBJECT wordt meegedeeld.\
-              \ Het gaat hier om de inhoud of content van het ENKELVOUDIG INFORMATIEOBJECT\
-              \ (in het spraakgebruik ‘de tekst van het document’) in het formaat\
-              \ zoals vastgelegd in Formaat. Veelal gaat het om de tekst van een ENKELVOUDIG\
-              \ INFORMATIEOBJECT (bijvoorbeeld in pdf-formaat). Het kan bijvoorbeeld\
-              \ ook een afbeelding (in bijvoorbeeld jpg-formaat) of een kaart (in\
-              \ bijvoorbeeld gmlformaat) betreffen. De mogelijkheid bestaat dat de\
-              \ inhoud in een (al dan niet separaat) bestand wordt uitgewisseld of\
-              \ dat er alleen verwezen wordt naar de locatie waar zich de inhoud bevindt.\
-              \ Hiertoe zijn de attribuutsoorten Bestandsnaam respectievelijk Link\
-              \ opgenomen. De content (data) van het enkelvoudig informatieobject\
-              \ in het formaat zoals gespecificeerd met de attribuutsoort 'Formaat'."
+            description: "<body>Datgene wat in een ENKELVOUDIG INFORMATIEOBJECT wordt\
+              \ meegedeeld.</body><body>Het gaat hier om de inhoud of content van\
+              \ het ENKELVOUDIG INFORMATIEOBJECT (in het spraakgebruik â€˜de tekst\
+              \ van het documentâ€™) in het formaat zoals vastgelegd in Formaat. Veelal\
+              \ gaat het om de tekst van een ENKELVOUDIG INFORMATIEOBJECT (bijvoorbeeld\
+              \ in pdf-formaat). Het kan bijvoorbeeld ook een afbeelding (in bijvoorbeeld\
+              \ jpg-formaat) of een kaart (in bijvoorbeeld gmlformaat) betreffen.\
+              \ De mogelijkheid bestaat dat de inhoud in een (al dan niet separaat)\
+              \ bestand wordt uitgewisseld of dat er alleen verwezen wordt naar de\
+              \ locatie waar zich de inhoud bevindt. Hiertoe zijn de attribuutsoorten\
+              \ Bestandsnaam respectievelijk Link opgenomen.</body><body>De content\
+              \ (data) van het enkelvoudig informatieobject in het formaat zoals gespecificeerd\
+              \ met de attribuutsoort 'Formaat'.</body>"
           link:
             type: "string"
             title: "Link"
-            description: "De URL waarmee de inhoud van het INFORMATIEOBJECT op te\
-              \ vragen is. Vanwege vooral technische belemmeringen kan het voorkomen\
-              \ dat de attribuutsoort Inhoud geen waarde heeft d.w.z. dat de inhoud\
-              \ van het informatieobject ('het document' in het spraakgebruik) niet\
-              \ uitgewisseld wordt. Het attribuutsoort Link verwijst dan naar de locatie\
-              \ waar de inhoud van het informatieobject ('het document') zich bevindt\
-              \ en schept de mogelijkheid de Inhoud ('het document') op te vragen.\
-              \ Een meer structurelere wijze om de Inhoud op te vragen, is uiteraard\
-              \ met behulp van de Identificatie."
+            description: "<body>De URL waarmee de inhoud van het INFORMATIEOBJECT\
+              \ op te vragen is.</body><body>Vanwege vooral technische belemmeringen\
+              \ kan het voorkomen dat de attribuutsoort Inhoud geen waarde heeft d.w.z.\
+              \ dat de inhoud van het informatieobject ('het document' in het spraakgebruik)\
+              \ niet uitgewisseld wordt. Het attribuutsoort Link verwijst dan naar\
+              \ de locatie waar de inhoud van het informatieobject ('het document')\
+              \ zich bevindt en schept de mogelijkheid de Inhoud ('het document')\
+              \ op te vragen. Een meer structurelere wijze om de Inhoud op te vragen,\
+              \ is uiteraard met behulp van de Identificatie.</body>"
             format: "uri"
           taal:
             type: "string"
             title: "Taal"
-            description: "Een taal van de intellectuele inhoud van het ENKELVOUDIG\
-              \ INFORMATIEOBJECT Het betreft het Dublin Core metadata-element ‘Language’\
-              \ met als toelichting: Recommended best practice is to use RFC 3066\
-              \ (RFC3066), which, in conjunction with ISO 639 (ISO639), defines two-\
-              \ and three-letter primary language tags with optional subtags. Examples\
-              \ include “en” or “eng” for English, “akk` for Akkadian, and “en-GB”\
-              \ for English used in the United Kingdom. De Nederlandse taal wordt\
-              \ gecodeerd als “dut”. bij voorkeur ISO 639-2/B"
+            description: "<body>Een taal van de intellectuele inhoud van het ENKELVOUDIG\
+              \ INFORMATIEOBJECT</body><body>Het betreft het Dublin Core metadata-element\
+              \ â€˜Languageâ€™ met als toelichting: Recommended best practice is to\
+              \ use RFC 3066 (RFC3066), which, in conjunction with ISO 639 (ISO639),\
+              \ defines two- and three-letter primary language tags with optional\
+              \ subtags. Examples include â€œenâ€? or â€œengâ€? for English, â€œakk`\
+              \ for Akkadian, and â€œen-GBâ€? for English used in the United Kingdom.\
+              \ De Nederlandse taal wordt gecodeerd als â€œdutâ€?.</body><body>bij\
+              \ voorkeur ISO 639-2/B</body>"
             maxLength: 20
             minLength: 1
     Informatieobject:
       type: "object"
-      description: "Geheel van gegevens met een eigen identiteit ongeacht zijn vorm,\
-        \ met de bijbehorende metadata ontvangen of opgemaakt door een natuurlijke\
+      description: "<body>Geheel van gegevens met een eigen identiteit ongeacht zijn\
+        \ vorm, met de bijbehorende metadata ontvangen of opgemaakt door een natuurlijke\
         \ en/of rechtspersoon bij de uitvoering van taken, zijnde een ENKELVOUDIG\
-        \ INFORMATIEOBJECT of een SAMENGESTELD INFORMATIEOBJECT. Een informatieobject\
+        \ INFORMATIEOBJECT of een SAMENGESTELD INFORMATIEOBJECT.</body><body>Een informatieobject\
         \ is een generiekere term voor het veelgebruikte begrip document dat beperkter\
         \ van reikwijdte is. Een informatieobject kan van alles zijn, ongeacht aard\
         \ en vorm: een tekstverwerkingsdocument, een papieren brief, een webpagina,\
@@ -6887,13 +7395,13 @@ components:
         \ uit meerdere fysieke informatieobjecten, zoals een aanvraag (als tekstdocument)\
         \ met bijbehorende tekening (CAD-formaat) en berekening (spreadsheet) of een\
         \ email met bijlage(n). Net zoals dezelfde aanvraag op papier met bijlagen\
-        \ als één informatieobject beschouwd kan worden. De fysieke vorm van hetgeen\
+        \ als Ã©Ã©n informatieobject beschouwd kan worden. De fysieke vorm van hetgeen\
         \ ontvangen of gecreeerd is, is dus niet (alleen) bepalend voor de afbakening\
         \ van dat wat als informatieobject beschouwd wordt. Zie Diagram Abstracte\
         \ en concrete objecttypen / informatieobjecten Een informatieobject dat door\
-        \ bijvoorbeeld de initiator van een zaak als één informatieobject wordt beschouwd,\
-        \ kan fysiek uit meerdere informatieobjecten bestaan. Een dergelijke groep\
-        \ fysieke informatieobjecten kan beschouwd worden als één informatieobject.\
+        \ bijvoorbeeld de initiator van een zaak als Ã©Ã©n informatieobject wordt\
+        \ beschouwd, kan fysiek uit meerdere informatieobjecten bestaan. Een dergelijke\
+        \ groep fysieke informatieobjecten kan beschouwd worden als Ã©Ã©n informatieobject.\
         \ Gezien de definitie kan er immers sprake zijn van het 'geheel van gegevens\
         \ met een eigen identiteit' waarbij alleen de vorm er toe heeft geleid dat\
         \ er drie fysieke informatieobjecten zijn ontvangen (tekstverwerkingsdocument,\
@@ -6914,8 +7422,8 @@ components:
         \ samengestelde informatieobjecten 'aangereikt' krijgen en deze transformeren\
         \ tot enkelvoudige informatieobjecten. INFORMATIEOBJECT heeft een N:M-relatie\
         \ naar ZAAK waarmee we aangeven dat een informatieobject relevant kan zijn\
-        \ voor meer dan één zaak. Dit modelleren we via het objecttype ZAAKINFORMATIEOBJECT.\
-        \ Dit is bijvoorbeeld het geval bij zgn. samengestelde brieven: één brief\
+        \ voor meer dan Ã©Ã©n zaak. Dit modelleren we via het objecttype ZAAKINFORMATIEOBJECT.\
+        \ Dit is bijvoorbeeld het geval bij zgn. samengestelde brieven: Ã©Ã©n brief\
         \ waarin meerdere zaken aanhangig gemaakt worden zoals een verzoek en een\
         \ klacht. Door informatieobjecten te registreren en aan een zaak te relateren\
         \ wordt het archief bij/van de zaak opgebouwd; alle informatieobjecten bij\
@@ -6929,12 +7437,12 @@ components:
         \ zodanig onbelangrijk dat zij niet archiefwaardig zijn d.w.z. niet bewaard\
         \ hoeven te worden om te voldoen aan wettelijke en/of administratieve eisen\
         \ en/of maatschappelijke behoeften. Een informatieobject zoals hier bedoeld,\
-        \ wordt een zgn. gearchiveerd informatieelement (‘archiefstuk’; in het engels\
-        \ 'record') zo gauw de zaakkenmerken aangeven dat alle daaraan gekoppelde\
+        \ wordt een zgn. gearchiveerd informatieelement (â€˜archiefstukâ€™; in het\
+        \ engels 'record') zo gauw de zaakkenmerken aangeven dat alle daaraan gekoppelde\
         \ informatieobjecten gearchiveerd dienen te zijn. Van ontvangen en verzonden\
-        \ informatieobjecten kunnen de afzenders en geadresseerden telkens op één\
-        \ van twee wijzen vastgelegd worden: gestructureerd door middel van de relatie\
-        \ naar BETROKKENE en ongestructureerd met de desbetreffende attribuutsoorten."
+        \ informatieobjecten kunnen de afzenders en geadresseerden telkens op Ã©Ã©\
+        n van twee wijzen vastgelegd worden: gestructureerd door middel van de relatie\
+        \ naar BETROKKENE en ongestructureerd met de desbetreffende attribuutsoorten.</body>"
       required:
       - "auteur"
       - "bronorganisatie"
@@ -6942,23 +7450,14 @@ components:
       - "informatieobjectidentificatie"
       - "titel"
       properties:
-        "@context":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@type":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
         auteur:
           type: "string"
           title: "Auteur"
-          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk\
-            \ is voor het creëren van de inhoud van het INFORMATIEOBJECT. Het kan\
-            \ zowel een medewerker of organisatorische eenheid van de zaakbehandelende\
+          description: "<body>De persoon of organisatie die in de eerste plaats verantwoordelijk\
+            \ is voor het creÃ«ren van de inhoud van het INFORMATIEOBJECT.</body><body>Het\
+            \ kan zowel een medewerker of organisatorische eenheid van de zaakbehandelende\
             \ organisatie betreffen als een externe partij (persoon of organisatie).\
-            \ Het betreft het Dublin Core metadata-element ‘Creator’ met als toelichting:\
+            \ Het betreft het Dublin Core metadata-element â€˜Creatorâ€™ met als toelichting:\
             \ Examples of Creator include a person, an organization, or a service.\
             \ Typically, the name of a Creator should be used to indicate the entity.\
             \ Van een ontvangen informatieobject kan de afzender de auteur zijn maar\
@@ -6969,758 +7468,643 @@ components:
             \ informatieobjecten waarbij van ondertekening geen sprake is (zoals bijvoorbeeld\
             \ bij het omzetten van de zaakgegevens naar een duurzaam bewaarbaar informatieobject\
             \ in pdf), degene die verantwoordelijk is voor de inhoud van het informatieobject\
-            \ vanuit zijn of haar rol bij de zaak (veelal degene in de rol van Zaakcoö\
-            rdinator). De naamgegevens van de auteur zijnde een betrokkene die in\
-            \ een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur niet in\
-            \ een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk\
+            \ vanuit zijn of haar rol bij de zaak (veelal degene in de rol van ZaakcoÃ\
+            ¶rdinator).</body><body>De naamgegevens van de auteur zijnde een betrokkene\
+            \ die in een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur\
+            \ niet in een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk\
             \ persoon of organisatie zijnde de auteur. In het laatste geval verdient\
             \ het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap\
-            \ wordt uitgeoefend."
+            \ wordt uitgeoefend.</body>"
           maxLength: 200
           minLength: 1
         bronorganisatie:
           type: "integer"
           title: "Bronorganisatie"
-          description: "bronorganisatie bronorganisatie Het RSIN van de Niet-natuurlijk\
-            \ persoon zijnde de organisatie die het informatieobject heeft gecreë\
-            erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd.\
-            \ Het betreft het RSIN (Rechtspersonen en Samenwerkingsverbanden InformatieNummer)\
-            \ zoals dat door de KvK in het NHR aan elk rechtspersoon en samenwerkingsverband\
-            \ is toegekend. Dit identificeert uniek de organisatie, zijnde een rechtspersoon\
-            \ of samenwerkingsverband, dat het informatieobject heeft gecreëerd of\
-            \ heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd.\
-            \ Met het laatste doelen we er op dat bij uitwisseling van een informatieobject\
-            \ tussen samenwerkende organisaties de unieke aanduiding van het informatieobject\
-            \ niet wijzigt mits de ontvangende organisatie geen wijzigingen in het\
-            \ informatieobject aanbrengt. In het laatste geval ontstaat een nieuw\
-            \ informatieobject. Het RSIN staat in het Handelsregister (NHR) en op\
-            \ het daaraan te ontlenen uittreksel. Deze attribuutsoort vormt tezamen\
-            \ met de Informatieobjectidentificatie de unieke aanduiding van een informatieobject\
-            \ voor geheel Nederland. De waarde van dit attribuutsoort wijzigt niet,\
-            \ ook niet indien (de behandeling van) het informatieobject over zou gaan\
-            \ naar een andere organisatie. Er is immers maar één organisatie die het\
-            \ informatieobject gecreëerd of als eerste vastgelegd heeft. De in het\
-            \ NHR voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden."
+          description: "<body>bronorganisatie</body><body>bronorganisatie</body><body>Het\
+            \ RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject\
+            \ heeft gecreÃ«erd of heeft ontvangen en als eerste in een samenwerkingsketen\
+            \ heeft vastgelegd.</body><body>Het betreft het RSIN (Rechtspersonen en\
+            \ Samenwerkingsverbanden InformatieNummer) zoals dat door de KvK in het\
+            \ NHR aan elk rechtspersoon en samenwerkingsverband is toegekend. Dit\
+            \ identificeert uniek de organisatie, zijnde een rechtspersoon of samenwerkingsverband,\
+            \ dat het informatieobject heeft gecreÃ«erd of heeft ontvangen en als\
+            \ eerste in een samenwerkingsketen heeft vastgelegd. Met het laatste doelen\
+            \ we er op dat bij uitwisseling van een informatieobject tussen samenwerkende\
+            \ organisaties de unieke aanduiding van het informatieobject niet wijzigt\
+            \ mits de ontvangende organisatie geen wijzigingen in het informatieobject\
+            \ aanbrengt. In het laatste geval ontstaat een nieuw informatieobject.\
+            \ Het RSIN staat in het Handelsregister (NHR) en op het daaraan te ontlenen\
+            \ uittreksel. Deze attribuutsoort vormt tezamen met de Informatieobjectidentificatie\
+            \ de unieke aanduiding van een informatieobject voor geheel Nederland.\
+            \ De waarde van dit attribuutsoort wijzigt niet, ook niet indien (de behandeling\
+            \ van) het informatieobject over zou gaan naar een andere organisatie.\
+            \ Er is immers maar Ã©Ã©n organisatie die het informatieobject gecreÃ«\
+            erd of als eerste vastgelegd heeft.</body><body>De in het NHR voorkomende\
+            \ unieke identificaties van rechtspersonen en samenwerkingsverbanden.</body>"
           maximum: 9.99999999E8
         creatiedatum:
           type: "string"
           title: "Creatiedatum"
-          description: "creatiedatum creatiedatum Een datum of een gebeurtenis in\
-            \ de levenscyclus van het INFORMATIEOBJECT. Deze datum verwijst gewoonlijk\
-            \ naar de creatie van het INFORMATIEOBJECT. Het betreft het Dublin Core\
-            \ metadata-element ‘Date’ met als toelichting: Typically, Date will be\
-            \ associated with the creation or availability of the resource. Recommended\
-            \ best practice for encoding the date value is defined in a profile of\
-            \ ISO 8601 (W3CDTF) and includes (among others) dates of the form YYYY-MM-DD.\
-            \ Alle geldige datums gelegen op of voor de huidige datum en tijd"
+          description: "<body>creatiedatum</body><body>creatiedatum</body><body>Een\
+            \ datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT.</body><body>Deze\
+            \ datum verwijst gewoonlijk naar de creatie van het INFORMATIEOBJECT.\
+            \ Het betreft het Dublin Core metadata-element â€˜Dateâ€™ met als toelichting:\
+            \ Typically, Date will be associated with the creation or availability\
+            \ of the resource. Recommended best practice for encoding the date value\
+            \ is defined in a profile of ISO 8601 (W3CDTF) and includes (among others)\
+            \ dates of the form YYYY-MM-DD.</body><body>Alle geldige datums gelegen\
+            \ op of voor de huidige datum en tijd</body>"
           format: "date"
         informatieobjectidentificatie:
           type: "string"
           title: "Informatieobjectidentificatie"
-          description: "informatieobjectidentificatie informatieobjectidentificatie\
-            \ Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT.\
-            \ Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers\
-            \ en/of leestekens, dat het informatieobject uniek identificeert binnen\
-            \ de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen\
-            \ en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven\
-            \ context’). Door combinatie met het RSIN van die organisatie, als waarde\
-            \ van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland\
+          description: "<body>informatieobjectidentificatie</body><body>informatieobjectidentificatie</body><body>Een\
+            \ binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT.</body><body>Het\
+            \ gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of\
+            \ leestekens, dat het informatieobject uniek identificeert binnen de organisatie\
+            \ die het informatieobject heeft gecreÃ«erd of heeft ontvangen en als\
+            \ eerste in een samenwerkingsketen heeft vastgelegd (cq. de â€˜gegeven\
+            \ contextâ€™). Door combinatie met het RSIN van die organisatie, als waarde\
+            \ van de attribuutsoort â€˜Bronorganisatieâ€™, wordt een voor geheel Nederland\
             \ unieke aanduiding van informatieobjecten verkregen. Het betreft het\
-            \ Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended\
+            \ Dublin Core metadata-element â€˜Identifierâ€™ met als toelichting: Recommended\
             \ best practice is to identify the resource by means of a string or number\
             \ conforming to a formal identification system. Formal identification\
             \ systems include but are not limited to the Uniform Resource Identifier\
             \ (URI) (including the Uniform Resource Locator (URL)), the Digital Object\
-            \ Identifier (DOI), and the International Standard Book Number (ISBN).\
-            \ Alle alfanumerieke tekens m.u.v. diacrieten"
+            \ Identifier (DOI), and the International Standard Book Number (ISBN).</body><body>Alle\
+            \ alfanumerieke tekens m.u.v. diacrieten</body>"
           maxLength: 40
           minLength: 1
-        ontvangstdatum:
-          type: "string"
-          title: "Ontvangstdatum"
-          description: "ontvangstdatum ontvangstdatum De datum waarop het INFORMATIEOBJECT\
-            \ ontvangen is. Het gaat hier om de datum waarop het INFORMATIEOBJECT\
-            \ ontvangen is door de zaakbehandelende organisatie(s), dus niet door\
-            \ een specifieke afdeling of medewerker daarvan. Alle geldige datums gelegen\
-            \ op, voor of na de huidige datum en tijd"
-          format: "date"
         titel:
           type: "string"
           title: "Titel"
-          description: "titel titel De naam waaronder het INFORMATIEOBJECT formeel\
-            \ bekend is. Het betreft het Dublin Core metadata-element ‘Title’ met\
-            \ als toelichting: Typically, Title will be a name by which the resource\
-            \ is formally known. alle alfanumerieke tekens"
+          description: "<body>titel</body><body>titel</body><body>De naam waaronder\
+            \ het INFORMATIEOBJECT formeel bekend is.</body><body>Het betreft het\
+            \ Dublin Core metadata-element â€˜Titleâ€™ met als toelichting: Typically,\
+            \ Title will be a name by which the resource is formally known.</body><body>alle\
+            \ alfanumerieke tekens</body>"
           maxLength: 200
           minLength: 1
         versie:
           type: "string"
           title: "Versie"
-          description: "versie versie Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT\
-            \ Het gaat hier om een versienummer zoals ‘0.2’ en 1.0’. Ofschoon we er\
-            \ voor gekozen hebben om zowel dit attribuuttype als het attribuuttype\
-            \ Status optioneel te verklaren, ware het aan te bevelen bij elk documemt\
-            \ in ieder geval één van beide attributen van een waarde te voorzien.\
-            \ Nb: De attribuutsoort is in versie 2.0 verplaatst van ENKELVOUDIG INFORMATIEOBJECT\
-            \ naar INFORMATIEOBJECT. Alle alfanumerieke tekens m.u.v. diacrieten"
+          description: "<body>versie</body><body>versie</body><body>Aanduiding van\
+            \ de bewerkingsfase van het INFORMATIEOBJECT</body><body>Het gaat hier\
+            \ om een versienummer zoals â€˜0.2â€™ en 1.0â€™. Ofschoon we er voor gekozen\
+            \ hebben om zowel dit attribuuttype als het attribuuttype Status optioneel\
+            \ te verklaren, ware het aan te bevelen bij elk documemt in ieder geval\
+            \ Ã©Ã©n van beide attributen van een waarde te voorzien. Nb: De attribuutsoort\
+            \ is in versie 2.0 verplaatst van ENKELVOUDIG INFORMATIEOBJECT naar INFORMATIEOBJECT.</body><body>Alle\
+            \ alfanumerieke tekens m.u.v. diacrieten</body>"
           maxLength: 5
-      discriminator:
-        propertyName: type
     AanwezigeDeelnemer_links:
       type: "object"
       properties:
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@context":
-            type: string
-            format: "uri"
-            example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
         self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         stemmen:
           title: "uitgebracht"
           type: "array"
-          description: "aanwezige raadsleden en statenleden mogen deelnemen aan een\
-            \ STEMMING Het gaat hierbij om een uitgebrachte stem van een STEMMING\
-            \ die niet over een persoon gaat. Die worden namelijk niet vastgelegd\
-            \ per uitgebrachte STEM."
+          description: "<body>aanwezige raadsleden en statenleden mogen deelnemen\
+            \ aan een STEMMING</body><body>Het gaat hierbij om een uitgebrachte stem\
+            \ van een STEMMING die niet over een persoon gaat. Die worden namelijk\
+            \ niet vastgelegd per uitgebrachte STEM.</body>"
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         natuurlijkPersonen:
-          title: "isEen"
-          type: "object"
-          description: "een NATUURLIJK PERSOON kan een deelnemer zijn van een VERGADERING"
-          properties:
-            href:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Href"
+          allOf:
+          - title: "isEen"
+            type: "object"
+            description: "<body>een NATUURLIJK PERSOON kan een deelnemer zijn van\
+              \ een VERGADERING</body>"
+          - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         spreekfragmenten:
           title: "spreekt"
           type: "array"
-          description: "Een AANWEZIGEDEELNEMER spreekt tijdens een AGENDAPUNT"
+          description: "<body>Een AANWEZIGE DEELNEMER spreekt tijdens een AGENDAPUNT</body>"
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         vergaderingen:
-          title: "isAanwezigBij"
-          type: "object"
-          description: "persoon met een functie neemt deel aan een vergadering"
-          properties:
-            href:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Href"
+          allOf:
+          - title: "isAanwezigBij"
+            type: "object"
+            description: "<body>persoon met een functie neemt deel aan een vergadering</body>"
+          - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
     Agendapunt_links:
       type: "object"
       properties:
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@context":
-            type: string
-            format: "uri"
-            example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
         self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         informatieobjecten:
           title: "heeftAlsBijlage"
           type: "array"
-          description: "Een AGENDAPUNT kan één of meerdere VERGADERSTUKken als bijlage\
-            \ hebben"
+          description: "<body>Een AGENDAPUNT kan Ã©Ã©n of meerdere VERGADERSTUKken\
+            \ als bijlage hebben</body>"
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         spreekfragmenten:
           title: "vindtPlaatsTijdens"
           type: "array"
-          description: "Een AANWEZIGEDEELNEMER spreekt tijdens een AGENDAPUNT"
+          description: "<body>Een AANWEZIGE DEELNEMER spreekt tijdens een AGENDAPUNT</body>"
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         agendapunten:
           title: "heeftAlsSubagendapunt"
           type: "array"
-          description: "Een AGENDAPUNT kan uit één of meer subAGENDAPUNTen en een\
-            \ subAGENDAPUNT kan weer bestaan uit één of meer sub(sub)AGENDAPUNTen."
+          description: "<body>Een AGENDAPUNT kan uit Ã©Ã©n of meer subAGENDAPUNTen\
+            \ en een subAGENDAPUNT kan weer bestaan uit Ã©Ã©n of meer sub(sub)AGENDAPUNTen.</body>"
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         stemmingen:
           title: "bevat"
           type: "array"
-          description: "Een STEMMING kan betrekking hebben op een AGENDAPUNT of subAGENDAPUNT.\
-            \ Een STEMMING kan betrekking hebben op één of meerdere VERGADERSTUKKEN\
-            \ zoals moties, amendementen, voorstellen en/of concept besluitstukken.\
-            \ Deze STEMMING hoort dan bij een AGENDAPUNT. Ook kan een STEMMING betrekking\
-            \ hebben tot een AGENDAPUNT. Men stemt dan over het betreffende AGENDAPUNT,\
-            \ bijvoorbeeld om de agenda vast te stellen of over alle onderliggende\
-            \ subAGENDAPUNTen in één keer."
+          description: "<body>Een STEMMING kan betrekking hebben op een AGENDAPUNT\
+            \ of subAGENDAPUNT.</body><body>Een STEMMING kan betrekking hebben op\
+            \ Ã©Ã©n of meerdere VERGADERSTUKKEN zoals moties, amendementen, voorstellen\
+            \ en/of concept besluitstukken. Deze STEMMING hoort dan bij een AGENDAPUNT.\
+            \ Ook kan een STEMMING betrekking hebben tot een AGENDAPUNT. Men stemt\
+            \ dan over het betreffende AGENDAPUNT, bijvoorbeeld om de agenda vast\
+            \ te stellen of over alle onderliggende subAGENDAPUNTen in Ã©Ã©n keer.</body>"
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         vergaderingen:
-          title: "wordtBehandeldTijdens"
-          type: "object"
-          description: "Een AGENDAPUNT wordt behandeld tijdens een VERGADERING."
-          properties:
-            href:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Href"
+          allOf:
+          - title: "wordtBehandeldTijdens"
+            type: "object"
+            description: "<body>Een AGENDAPUNT wordt behandeld tijdens een VERGADERING.</body>"
+          - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
     Amendement_links:
       type: "object"
       properties:
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@context":
-            type: string
-            format: "uri"
-            example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
         self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         amendementen:
-          title: "heeftBetrekkingOp"
-          type: "object"
-          description: "een subAMENDEMENT is een wijzigingsvoorstel voor een AMENDEMENT"
-          properties:
-            href:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Href"
+          allOf:
+          - title: "heeftBetrekkingOp"
+            type: "object"
+            description: "<body>een subAMENDEMENT is een wijzigingsvoorstel voor een\
+              \ AMENDEMENT</body>"
+          - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         voorstellen:
-          title: "hoortBij"
-          type: "object"
-          description: "een AMENDEMENT heeft betrekking op een VOORSTEL"
-          properties:
-            href:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Href"
-    Motie_links:
-      type: "object"
-      properties:
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@context":
-            type: string
-            format: "uri"
-            example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
-        self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
-    Voorstel_links:
-      type: "object"
-      properties:
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@context":
-            type: string
-            format: "uri"
-            example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
-        self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+          allOf:
+          - title: "hoortBij"
+            type: "object"
+            description: "<body>een AMENDEMENT heeft betrekking op een VOORSTEL</body>"
+          - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
     Antwoord_links:
       type: "object"
       properties:
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@context":
-            type: string
-            format: "uri"
-            example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
         self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         vragen:
-          title: "behorendBij"
-          type: "object"
-          description: "het antwoord behorend bij een eerder gestelde vraag"
-          properties:
-            href:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Href"
+          allOf:
+          - title: "behorendBij"
+            type: "object"
+            description: "<body>het antwoord behorend bij een eerder gestelde vraag</body>"
+          - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
     Besluit_links:
       type: "object"
       properties:
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@context":
-            type: string
-            format: "uri"
-            example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
         self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         stemmingen:
           title: "genomenWegens"
           type: "array"
-          description: "De uitslag van een STEMMING leidt een BESLUIT"
+          description: "<body>De uitslag van een STEMMING leidt een BESLUIT</body>"
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
     DagelijksBestuur_links:
       type: "object"
       properties:
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@context":
-            type: string
-            format: "uri"
-            example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
         self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         voorstellen:
-          title: "heeftIngediend"
-          type: "object"
-          description: "Een VOORSTEL kan ingediend worden door het college of door\
-            \ de gedeputeerde staten"
-          properties:
-            href:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Href"
+          allOf:
+          - title: "heeftIngediend"
+            type: "object"
+            description: "<body>Een VOORSTEL kan ingediend worden door het college\
+              \ of door de gedeputeerde staten</body>"
+          - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         collegelidmaatschappen:
           title: "iaLidVan"
           type: "array"
-          description: "De lidmaatschap van de burgemeester en wethouders van het\
-            \ college of van de commissaris en gedeputeerden van de gedeputeerde staten"
+          description: "<body>De lidmaatschap van de burgemeester en wethouders van\
+            \ het college of van de commissaris en gedeputeerden van de gedeputeerde\
+            \ staten</body>"
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
     DagelijksBestuurLidmaatschap_links:
       type: "object"
       properties:
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@context":
-            type: string
-            format: "uri"
-            example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
         self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         colleges:
           title: "isLidVan"
           type: "array"
-          description: "De lidmaatschap van de burgemeester en wethouders van het\
-            \ college of van de commissaris en gedeputeerden van de gedeputeerde staten"
+          description: "<body>De lidmaatschap van de burgemeester en wethouders van\
+            \ het college of van de commissaris en gedeputeerden van de gedeputeerde\
+            \ staten</body>"
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         collegelidmaatschappen:
           title: "heeftZiitingIn"
           type: "array"
-          description: "De lidmaatschap van de burgemeester en wethouders van het\
-            \ college of van de commissaris en gedeputeerden van de gedeputeerde staten"
+          description: "<body>De lidmaatschap van de burgemeester en wethouders van\
+            \ het college of van de commissaris en gedeputeerden van de gedeputeerde\
+            \ staten</body>"
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
     Fractie_links:
       type: "object"
       properties:
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@context":
-            type: string
-            format: "uri"
-            example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
         self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         stemresultatenperfractie:
           title: "wordtDeelgenomenDoor"
           type: "array"
-          description: "Het resultaat van de STEMMING per FRACTIE en wordt afgeleid\
-            \ van de uitgebrachte STEMmen. Juridisch gezien kunnen alleen raadsleden\
-            \ stemmen bij een raadsVERGADERING. In de praktijk wordt in de lijst met\
-            \ BESLUITen soms wel getoond welke FRACTIEs voor en/of tegen een BESLUIT\
-            \ waren."
+          description: "<body>Het resultaat van de STEMMING per FRACTIE en wordt afgeleid\
+            \ van de uitgebrachte STEMmen.</body><body>Juridisch gezien kunnen alleen\
+            \ raadsleden stemmen bij een raadsVERGADERING. In de praktijk wordt in\
+            \ de lijst met BESLUITen soms wel getoond welke FRACTIEs voor en/of tegen\
+            \ een BESLUIT waren.</body>"
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         fractielidmaatschappen:
           title: "bestaatUit"
           type: "array"
-          description: "De lidmaatschap van raadsleden/statenleden en burgerleden\
-            \ van een fractie"
+          description: "<body>De lidmaatschap van raadsleden/statenleden en burgerleden\
+            \ van een fractie</body>"
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
     FractieLidmaatschap_links:
       type: "object"
       properties:
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@context":
-            type: string
-            format: "uri"
-            example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
         self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         fracties:
-          title: "isLidVan"
-          type: "object"
-          description: "De lidmaatschap van raadsleden/statenleden en burgerleden\
-            \ van een fractie"
-          properties:
-            href:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Href"
+          allOf:
+          - title: "isLidVan"
+            type: "object"
+            description: "<body>De lidmaatschap van raadsleden/statenleden en burgerleden\
+              \ van een fractie</body>"
+          - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         natuurlijkPersonen:
-          title: "bestaatUit"
-          type: "object"
-          description: "De lidmaatschap van raadsleden/statenleden en burgerleden\
-            \ van een fractie"
-          properties:
-            href:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Href"
+          allOf:
+          - title: "bestaatUit"
+            type: "object"
+            description: "<body>De lidmaatschap van raadsleden/statenleden en burgerleden\
+              \ van een fractie</body>"
+          - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
     IngekomenStuk_links:
       type: "object"
       properties:
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@context":
-            type: string
-            format: "uri"
-            example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
         self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         natuurlijkPersonen:
           title: "isIngediendDoor"
           type: "array"
           description: ""
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         organisatorischeEenheden:
           title: "isIngedienDoor"
           type: "array"
-          description: "een INFORMATIEOBJECT kan ingediend zijn door een VERGADERDEELNEMER"
+          description: "<body>een INFORMATIEOBJECT kan ingediend zijn door een VERGADERDEELNEMER</body>"
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
     Mededeling_links:
       type: "object"
       properties:
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@context":
-            type: string
-            format: "uri"
-            example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
         self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
+    Motie_links:
+      type: "object"
+      properties:
+        self:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
     NatuurlijkPersoon_links:
       type: "object"
       properties:
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@context":
-            type: string
-            format: "uri"
-            example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
         self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         fractielidmaatschappen:
           title: "isLidVan"
           type: "array"
-          description: "De lidmaatschap van raadsleden/statenleden en burgerleden\
-            \ van een fractie"
+          description: "<body>De lidmaatschap van raadsleden/statenleden en burgerleden\
+            \ van een fractie</body>"
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         natuurlijkePersonen:
           title: "isIngediendDoor"
           type: "array"
-          description: "een INFORMATIEOBJECT kan ingediend zijn door een VERGADERDEELNEMER"
+          description: "<body>een INFORMATIEOBJECT kan ingediend zijn door een VERGADERDEELNEMER</body>"
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         collegelidmaatschappen:
           title: "heeftZittingIn"
           type: "array"
-          description: "De lidmaatschap van de burgemeester en wethouders van het\
-            \ college of van de commissaris en gedeputeerden van de gedeputeerde staten"
+          description: "<body>De lidmaatschap van de burgemeester en wethouders van\
+            \ het college of van de commissaris en gedeputeerden van de gedeputeerde\
+            \ staten</body>"
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
     Spreekfragment_links:
       type: "object"
       properties:
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@context":
-            type: string
-            format: "uri"
-            example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
         self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         agendapunten:
-          title: "vindtPlaatsTijdens"
-          type: "object"
-          description: "Een AANWEZIGEDEELNEMER spreekt tijdens een AGENDAPUNT"
-          properties:
-            href:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Href"
+          allOf:
+          - title: "vindtPlaatsTijdens"
+            type: "object"
+            description: "<body>Een AANWEZIGE DEELNEMER spreekt tijdens een AGENDAPUNT</body>"
+          - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         aanwezigedeelnemers:
-          title: "wordtGesprokenDoor"
-          type: "object"
-          description: "Een AANWEZIGEDEELNEMER spreekt tijdens een AGENDAPUNT"
-          properties:
-            href:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Href"
+          allOf:
+          - title: "wordtGesprokenDoor"
+            type: "object"
+            description: "<body>Een AANWEZIGE DEELNEMER spreekt tijdens een AGENDAPUNT</body>"
+          - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
     Stem_links:
       type: "object"
       properties:
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@context":
-            type: string
-            format: "uri"
-            example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
         self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         aanwezigeDeelnemers:
-          title: "uitgebrachtDoor"
-          type: "object"
-          description: "aanwezige raadsleden en statenleden mogen deelnemen aan een\
-            \ STEMMING Het gaat hierbij om een uitgebrachte stem van een STEMMING\
-            \ die niet over een persoon gaat. Die worden namelijk niet vastgelegd\
-            \ per uitgebrachte STEM."
-          properties:
-            href:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Href"
+          allOf:
+          - title: "uitgebrachtDoor"
+            type: "object"
+            description: "<body>aanwezige raadsleden en statenleden mogen deelnemen\
+              \ aan een STEMMING</body><body>Het gaat hierbij om een uitgebrachte\
+              \ stem van een STEMMING die niet over een persoon gaat. Die worden namelijk\
+              \ niet vastgelegd per uitgebrachte STEM.</body>"
+          - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         stemmingen:
-          title: "uitgebrachtTijdens"
-          type: "object"
-          description: "aanwezige raadsleden en statenleden mogen deelnemen aan een\
-            \ STEMMING Het gaat hierbij om een uitgebrachte stem van een STEMMING\
-            \ die niet over een persoon gaat. Die worden namelijk niet vastgelegd\
-            \ per uitgebrachte STEM."
-          properties:
-            href:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Href"
+          allOf:
+          - title: "uitgebrachtTijdens"
+            type: "object"
+            description: "<body>aanwezige raadsleden en statenleden mogen deelnemen\
+              \ aan een STEMMING</body><body>Het gaat hierbij om een uitgebrachte\
+              \ stem van een STEMMING die niet over een persoon gaat. Die worden namelijk\
+              \ niet vastgelegd per uitgebrachte STEM.</body>"
+          - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
     Stemming_links:
       type: "object"
       properties:
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@context":
-            type: string
-            format: "uri"
-            example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
         self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         besluitvormingsstukken:
-          title: "heeftBetrekkingOp"
-          type: "object"
-          description: "Een STEMMING heeft vaak betrekking op een VERGADERSTUK"
-          properties:
-            href:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Href"
+          allOf:
+          - title: "heeftBetrekkingOp"
+            type: "object"
+            description: "<body>Een STEMMING heeft vaak betrekking op een VERGADERSTUK</body>"
+          - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         stemmen:
           title: "uitgebrachttijdens"
           type: "array"
-          description: "aanwezige raadsleden en statenleden mogen deelnemen aan een\
-            \ STEMMING Het gaat hierbij om een uitgebrachte stem van een STEMMING\
-            \ die niet over een persoon gaat. Die worden namelijk niet vastgelegd\
-            \ per uitgebrachte STEM."
+          description: "<body>aanwezige raadsleden en statenleden mogen deelnemen\
+            \ aan een STEMMING</body><body>Het gaat hierbij om een uitgebrachte stem\
+            \ van een STEMMING die niet over een persoon gaat. Die worden namelijk\
+            \ niet vastgelegd per uitgebrachte STEM.</body>"
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         besluiten:
-          title: "leidtTot"
-          type: "object"
-          description: "De uitslag van een STEMMING leidt een BESLUIT"
-          properties:
-            href:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Href"
+          allOf:
+          - title: "leidtTot"
+            type: "object"
+            description: "<body>De uitslag van een STEMMING leidt een BESLUIT</body>"
+          - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         agendapunten:
-          title: "hoortBijOfKanBetrekkingHebbenOp"
-          type: "object"
-          description: "Een STEMMING kan betrekking hebben op een AGENDAPUNT of subAGENDAPUNT.\
-            \ Een STEMMING kan betrekking hebben op één of meerdere VERGADERSTUKKEN\
-            \ zoals moties, amendementen, voorstellen en/of concept besluitstukken.\
-            \ Deze STEMMING hoort dan bij een AGENDAPUNT. Ook kan een STEMMING betrekking\
-            \ hebben tot een AGENDAPUNT. Men stemt dan over het betreffende AGENDAPUNT,\
-            \ bijvoorbeeld om de agenda vast te stellen of over alle onderliggende\
-            \ subAGENDAPUNTen in één keer."
-          properties:
-            href:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Href"
+          allOf:
+          - title: "hoortBijOfKanBetrekkingHebbenOp"
+            type: "object"
+            description: "<body>Een STEMMING kan betrekking hebben op een AGENDAPUNT\
+              \ of subAGENDAPUNT.</body><body>Een STEMMING kan betrekking hebben op\
+              \ Ã©Ã©n of meerdere VERGADERSTUKKEN zoals moties, amendementen, voorstellen\
+              \ en/of concept besluitstukken. Deze STEMMING hoort dan bij een AGENDAPUNT.\
+              \ Ook kan een STEMMING betrekking hebben tot een AGENDAPUNT. Men stemt\
+              \ dan over het betreffende AGENDAPUNT, bijvoorbeeld om de agenda vast\
+              \ te stellen of over alle onderliggende subAGENDAPUNTen in Ã©Ã©n keer.</body>"
+          - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         stemresultatenperfractie:
           title: "neemtDeelAan"
           type: "array"
-          description: "Het resultaat van de STEMMING per FRACTIE en wordt afgeleid\
-            \ van de uitgebrachte STEMmen. Juridisch gezien kunnen alleen raadsleden\
-            \ stemmen bij een raadsVERGADERING. In de praktijk wordt in de lijst met\
-            \ BESLUITen soms wel getoond welke FRACTIEs voor en/of tegen een BESLUIT\
-            \ waren."
+          description: "<body>Het resultaat van de STEMMING per FRACTIE en wordt afgeleid\
+            \ van de uitgebrachte STEMmen.</body><body>Juridisch gezien kunnen alleen\
+            \ raadsleden stemmen bij een raadsVERGADERING. In de praktijk wordt in\
+            \ de lijst met BESLUITen soms wel getoond welke FRACTIEs voor en/of tegen\
+            \ een BESLUIT waren.</body>"
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
     StemresultaatPerFractie_links:
       type: "object"
       properties:
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@context":
-            type: string
-            format: "uri"
-            example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
         self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         fracties:
-          title: "wordt DeelgenomenDoor"
-          type: "object"
-          description: "Het resultaat van de STEMMING per FRACTIE en wordt afgeleid\
-            \ van de uitgebrachte STEMmen. Juridisch gezien kunnen alleen raadsleden\
-            \ stemmen bij een raadsVERGADERING. In de praktijk wordt in de lijst met\
-            \ BESLUITen soms wel getoond welke FRACTIEs voor en/of tegen een BESLUIT\
-            \ waren."
-          properties:
-            href:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Href"
+          allOf:
+          - title: "wordt DeelgenomenDoor"
+            type: "object"
+            description: "<body>Het resultaat van de STEMMING per FRACTIE en wordt\
+              \ afgeleid van de uitgebrachte STEMmen.</body><body>Juridisch gezien\
+              \ kunnen alleen raadsleden stemmen bij een raadsVERGADERING. In de praktijk\
+              \ wordt in de lijst met BESLUITen soms wel getoond welke FRACTIEs voor\
+              \ en/of tegen een BESLUIT waren.</body>"
+          - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         stemmingen:
-          title: "neemtDeelAan"
-          type: "object"
-          description: "Het resultaat van de STEMMING per FRACTIE en wordt afgeleid\
-            \ van de uitgebrachte STEMmen. Juridisch gezien kunnen alleen raadsleden\
-            \ stemmen bij een raadsVERGADERING. In de praktijk wordt in de lijst met\
-            \ BESLUITen soms wel getoond welke FRACTIEs voor en/of tegen een BESLUIT\
-            \ waren."
-          properties:
-            href:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Href"
+          allOf:
+          - title: "neemtDeelAan"
+            type: "object"
+            description: "<body>Het resultaat van de STEMMING per FRACTIE en wordt\
+              \ afgeleid van de uitgebrachte STEMmen.</body><body>Juridisch gezien\
+              \ kunnen alleen raadsleden stemmen bij een raadsVERGADERING. In de praktijk\
+              \ wordt in de lijst met BESLUITen soms wel getoond welke FRACTIEs voor\
+              \ en/of tegen een BESLUIT waren.</body>"
+          - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
     Toezegging_links:
       type: "object"
       properties:
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@context":
-            type: string
-            format: "uri"
-            example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
         self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
     Vergadering_links:
       type: "object"
       properties:
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@context":
-            type: string
-            format: "uri"
-            example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
         self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         aanwezigeDeelnemers:
           title: "isAanwezigBij"
           type: "array"
-          description: "persoon met een functie neemt deel aan een vergadering"
+          description: "<body>persoon met een functie neemt deel aan een vergadering</body>"
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
+        vragen:
+          title: "heeftAlsBijlage"
+          type: "array"
+          description: "<body>Een VERGADERING kan ook Ã©Ã©n of meer VERGADERSTUKKEN\
+            \ als bijlage hebben.</body><body>Dit zijn bijvoorbeeld de notulen en\
+            \ de besluitenlijst van de vorige VERGADERING</body>"
+          items:
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         agendapunten:
           title: "wordtBehandeldTijdens"
           type: "array"
-          description: "Een AGENDAPUNT wordt behandeld tijdens een VERGADERING."
+          description: "<body>Een AGENDAPUNT wordt behandeld tijdens een VERGADERING.</body>"
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
-        informatieobjecten:
-          title: "heeftAlsBijlage"
-          type: "array"
-          description: "Een VERGADERING kan ook één of meer VERGADERSTUKKEN als bijlage\
-            \ hebben. Dit zijn bijvoorbeeld de notulen en de besluitenlijst van de\
-            \ vorige VERGADERING"
-          items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         vergaderingen:
           title: "heeftAlsDeelvergadering"
           type: "array"
-          description: "Een VERGADERING kan uit één of meerdere deel-VERGADERINGen bestaan"
+          description: "<body>Een VERGADERING kan uit Ã©Ã©n of meerdere deel-VERGADERINGen\
+            \ bestaan</body>"
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
+    Voorstel_links:
+      type: "object"
+      properties:
+        self:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
     Vraag_links:
       type: "object"
       properties:
-        "@id":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
-        "@context":
-            type: string
-            format: "uri"
-            example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
         self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         antwoorden:
           title: "heeft"
           type: "array"
-          description: "het antwoord behorend bij een eerder gestelde vraag"
+          description: "<body>het antwoord behorend bij een eerder gestelde vraag</body>"
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalLink"
-    VraagType:
-      type: "string"
-      description: "de type van de vraag de type van de vraagde type van de vraag:\n\
-        * `Technische vraag` - Technische vraag\n* `Mondelinge politieke vraag` -\
-        \ Mondelinge politieke vraag\n* `Schriftelijke politieke vraag` - Schriftelijke\
-        \ politieke vraag"
-      enum:
-      - "Technische vraag"
-      - "Mondelinge politieke vraag"
-      - "Schriftelijke politieke vraag"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
+    Gremium:
+      type: "object"
+      description: "<body>De referentielijst met alle gremia in een gemeente</body><body><p>De\
+        \ referentielijst met alle gremia in een gemeente</p></body><body></body>"
+      required:
+      - "gremiumNaam"
+      - "gremiumidentificatie"
+      properties:
+        gremiumNaam:
+          type: "string"
+          title: "Gremium naam"
+          description: "<body>De naam van het gremium</body><body><p>De naam van het\
+            \ gremium</p></body><body></body>"
+          maxLength: 100
+          minLength: 1
+        gremiumidentificatie:
+          type: "string"
+          title: "gremiumidentificatie"
+          description: "<body><p>De identificatie van een gremium</p></body><body>De\
+            \ eerste vier karakter zijn de gemeentecode, gevolgd door een volgnummer\
+            \ van 7 cijfers met voorloopnullen.</body>"
+          maxLength: 10
+          minLength: 1
+    NaamNatuurlijkPersoon:
+      type: "object"
+      description: "<body>De naam van een NATUURLIJK PERSOON</body>"
+      required:
+      - "achternaam"
+      properties:
+        achternaam:
+          type: "string"
+          title: "Achternaam"
+          description: "<body>De achternaam van een NATUURLIJK PERSOON</body>"
+          maxLength: 200
+          minLength: 1
+        tussenvoegsel:
+          type: "string"
+          title: "Tussenvoegsel"
+          description: "<body>De tussenvoegsel van een NATUURLIJK PERSOON</body>"
+          maxLength: 20
+        voorletters:
+          type: "string"
+          title: "Voorletters"
+          description: "<body>De voorletters van een NATUURLIJK PERSOON</body>"
+          maxLength: 20
+        voornamen:
+          type: "string"
+          title: "Voornamen"
+          description: "<body>De voornamen van een NATUURLIJK PERSOON.</body>"
+          maxLength: 200
+    NevenfunctieNatuurlijkePersoon:
+      type: "object"
+      description: "<body>De nevenfuncties van een NATUURLIJKE PERSOON</body>"
+      required:
+      - "datumAanvangNevenfunctie"
+      - "indicatorBezoldigd"
+      - "omschrijvingNevenfuctie"
+      properties:
+        aantalUrenPerMaand:
+          type: "integer"
+          title: "Aantal uren per maand"
+          description: "<body>Het aantal uren dat per maand besteed wordt aan de nevenfunctie</body>"
+          maximum: 999
+        datumAanvangNevenfunctie:
+          type: "string"
+          title: "Datum aanvang nevenfunctie"
+          description: "<body>De datum van aanvang van de nevenfunctie</body>"
+          format: "date"
+        datumEindeNevenfunctie:
+          type: "string"
+          title: "Datum einde nevenfunctie"
+          description: "<body>De datum van het einde van de nevenfunctie</body>"
+          format: "date"
+        datumMelding:
+          type: "string"
+          title: "Datum melding"
+          description: "<body>De datum waarop de nevenfunctie gemeld is bij de griffie.</body>"
+          format: "date"
+        indicatorBezoldigd:
+          type: "boolean"
+          title: "Indicator bezoldigd"
+          description: "<body>Indicator of de nevenfunctie uitgevoerd wordt tegen\
+            \ betaling.</body>"
+        indicatorInFunctieVanLidmaatschap:
+          type: "boolean"
+          title: "Indicator nevenfunctie vanwege lidmaatschap"
+          description: "<body>Indicator die aangeeft of de nevenfunctie wordt vervuld\
+            \ vanwege de lidmaatschap van de Raad of de Staten.</body>"
+        naamOrganisatieNevenfunctie:
+          type: "string"
+          title: "Naam organisatie nevenfunctie"
+          description: "<body>De naam van de organisatie van de nevenfunctie</body>"
+          maxLength: 100
+        omschrijvingNevenfuctie:
+          type: "string"
+          title: "Omschrijving nevenfunctie"
+          description: "<body>De omschrijving van de nevenfunctie.</body>"
+          maxLength: 100
+          minLength: 1
+    StemmingOverPersonen:
+      type: "object"
+      description: "<body>De uitslag van de stemming over personen</body><body>De\
+        \ individuele uitgebrachte STEMmen over personen zijn geheim. Alleen het aantal\
+        \ uitgebrachte stemmen per kandidaat is bekend.</body>"
+      required:
+      - "aantalUitgebrachteStemmen"
+      - "naamKandidaat"
+      properties:
+        aantalUitgebrachteStemmen:
+          type: "integer"
+          title: "Aantal uitgebrachte stemmen"
+          description: "<body>Het aantal uitgebracht stemmen behorend bij een kandidaat</body>"
+          maximum: 999
+        naamKandidaat:
+          type: "string"
+          title: "Naam kandidaat"
+          description: "<body>De naam van de kandidaat over wie gestemd is</body>"
+          maxLength: 100
+          minLength: 1
     FractieStemResultaat:
       type: "string"
-      description: "duiding van de mogelijke resultaten van de STEMMING per FRACTIE:\n\
-        * `A` - Aangenomen\n* `V` - Verworpen\n* `VD` - Verdeeld"
+      description: "<body>duiding van de mogelijke resultaten van de STEMMING per\
+        \ FRACTIE</body>:\n* `A` - Aangenomen\n* `V` - Verworpen\n* `VD` - Verdeeld"
       enum:
       - "A"
       - "V"
       - "VD"
-    StemKeuze:
-      type: "string"
-      description: "de mogelijke keuze van een uitgebrachte STEMde mogelijke keuze\
-        \ van een uitgebrachte STEM:\n* `V` - Voor\n* `T` - Tegen\n* `A` - Afwezig\n\
-        * `O` - Onthouden"
-      enum:
-      - "V"
-      - "T"
-      - "A"
-      - "O"
-    VergaderingStatus:
-      type: "string"
-      description: "duiding van de statussen van een VERGADERING:\n* `0` - Gepland\n\
-        * `1` - Gehouden\n* `2` - Geannuleerd"
-      enum:
-      - "0"
-      - "1"
-      - "2"
-    StemmingResultaat:
-      type: "string"
-      description: "duiding van het resultaat van een STEMMING:\n* `V` - Voor\n* `T`\
-        \ - Tegen\n* `G` - Gelijk"
-      enum:
-      - "V"
-      - "T"
-      - "G"
-    MotieType:
-      type: "string"
-      description: "duiding van het type van een MOTIE:\n* `R` - Voorstel\n* `A` -\
-        \ Afkeuring\n* `T` - Treurnis\n* `W` - Wantrouwen\n* `V` - Vreemd\n* `O` -\
-        \ Overig"
-      enum:
-      - "R"
-      - "A"
-      - "T"
-      - "W"
-      - "V"
-      - "O"
     Functie:
       type: "string"
-      description: "de mogelijke functies die een persoon heeft binnen de raadsVERGADERING:\n\
+      description: "<body>de mogelijke functies die een persoon heeft binnen de raadsVERGADERING</body>:\n\
         * `BM` - Burgemeester\n* `W` - Wethouder\n* `R` - Raadslid\n* `BL` - Burgerlid\n\
         * `G` - Griffier\n* `GS` - Gemeentesecretaris\n* `A` - Ambtenaar/Medewerker\n\
         * `AD` - Adviseur of Deskundige\n* `O` - Overig\n* `CK` - Commissaris van\
@@ -7740,29 +8124,33 @@ components:
       - "GD"
       - "PS"
       - "S"
-    Vervalreden:
+    Geslacht:
       type: "string"
-      description: "Benamingen van de gronden op basis waarvan een besluit is of komt\
-        \ te vervallen.Benamingen van de gronden op basis waarvan een besluit is of\
-        \ komt te vervallen.:\n* `T` - Besluit met tijdelijke werking\n* `IO` - Besluit\
-        \ ingetrokken door overheid\n* `IB` - Besluit ingetrokken o.v.v. belanghebbende"
+      description: "<body>duiding van het geslacht van een persoon</body>:\n* `M`\
+        \ - Man\n* `V` - Vrouw\n* `A` - Anders\n* `O` - Onbekend"
       enum:
+      - "M"
+      - "V"
+      - "A"
+      - "O"
+    MotieType:
+      type: "string"
+      description: "<body>duiding van het type van een MOTIE</body>:\n* `R` - Voorstel\n\
+        * `A` - Afkeuring\n* `T` - Treurnis\n* `W` - Wantrouwen\n* `V` - Vreemd\n\
+        * `O` - Overig"
+      enum:
+      - "R"
+      - "A"
       - "T"
-      - "IO"
-      - "IB"
-    StemmingsType:
-      type: "string"
-      description: "duiding van het type van een STEMMING:\n* `H` - Hoofdelijk\n*\
-        \ `F` - Regulier\n* `S` - Schriftelijk"
-      enum:
-      - "H"
-      - "F"
-      - "S"
+      - "W"
+      - "V"
+      - "O"
     RolNaam:
       type: "string"
-      description: "duiding van de rollen van een natuurlijke persoon tijdens een\
-        \ vergadering:\n* `V` - Voorzitter\n* `VV` - Vice-voorzitter\n* `R` - Raadslid\n\
-        * `I` - Inspreker\n* `O` - Overig\n* `P` - Portefeuillehouder\n* `S` - Statenlid"
+      description: "<body>duiding van de rollen van een natuurlijke persoon tijdens\
+        \ een vergadering</body>:\n* `V` - Voorzitter\n* `VV` - Vice-voorzitter\n\
+        * `R` - Raadslid\n* `I` - Inspreker\n* `O` - Overig\n* `P` - Portefeuillehouder\n\
+        * `S` - Statenlid"
       enum:
       - "V"
       - "VV"
@@ -7771,122 +8159,57 @@ components:
       - "O"
       - "P"
       - "S"
-    Geslacht:
+    StemKeuze:
       type: "string"
-      description: "duiding van het geslacht van een persoon:\n* `M` - Man\n* `V`\
-        \ - Vrouw\n* `A` - Anders\n* `O` - Onbekend"
+      description: "<body>de mogelijke keuze van een uitgebrachte STEM</body><body><p>de\
+        \ mogelijke keuze van een uitgebrachte STEM</p></body>:\n* `V` - Voor\n* `T`\
+        \ - Tegen\n* `A` - Afwezig\n* `O` - Onthouden"
       enum:
-      - "M"
       - "V"
+      - "T"
       - "A"
       - "O"
+    StemmingResultaat:
+      type: "string"
+      description: "<body>duiding van het resultaat van een STEMMING</body>:\n* `V`\
+        \ - Voor\n* `T` - Tegen\n* `G` - Gelijk"
+      enum:
+      - "V"
+      - "T"
+      - "G"
+    StemmingsType:
+      type: "string"
+      description: "<body>duiding van het type van een STEMMING</body>:\n* `H` - Hoofdelijk\n\
+        * `F` - Regulier\n* `S` - Schriftelijk"
+      enum:
+      - "H"
+      - "F"
+      - "S"
+    VergaderingStatus:
+      type: "string"
+      description: "<body>duiding van de statussen van een VERGADERING</body>:\n*\
+        \ `0` - Gepland\n* `1` - Gehouden\n* `2` - Geannuleerd"
+      enum:
+      - "0"
+      - "1"
+      - "2"
     VergaderingsType:
       type: "string"
-      description: "de mogelijke typen van een VERGADERING behorende bij de gemeenteraad:\n\
-        * `R` - Raadsvergadering\n* `C` - Commissievergadering\n* `P` - Presidium\n\
-        * `S` - Statenvergadering"
+      description: "<body>de mogelijke typen van een VERGADERING behorende bij de\
+        \ gemeenteraad</body>:\n* `R` - Raadsvergadering\n* `C` - Commissievergadering\n\
+        * `P` - Presidium\n* `S` - Statenvergadering"
       enum:
       - "R"
       - "C"
       - "P"
       - "S"
-  responses:
-    '400':
-      description: Bad Request
-      headers:
-        api-version:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-      content:
-        application/problem+json:
-          schema:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/ValidatieFoutbericht"
-    '401':
-      description: Unauthorized
-      headers:
-        api-version:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-      content:
-        application/problem+json:
-          schema:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht401"
-    '403':
-      description: Forbidden
-      headers:
-        api-version:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-      content:
-        application/problem+json:
-          schema:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht403"
-    '404':
-      description: Not Found
-      headers:
-        api-version:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-      content:
-        application/problem+json:
-          schema:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht404"
-    '406':
-      description: Not Acceptable
-      headers:
-        api-version:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-      content:
-        application/problem+json:
-          schema:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht406"
-    '409':
-      description: Conflict
-      headers:
-        api-version:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-      content:
-        application/problem+json:
-          schema:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht409"
-    '410':
-      description: Gone
-      headers:
-        api-version:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-      content:
-        application/problem+json:
-          schema:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht410"
-    '415':
-      description: Unsupported Media Type
-      headers:
-        api-version:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-      content:
-        application/problem+json:
-          schema:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht415"
-    '429':
-      description: Too Many Requests
-      headers:
-        api-version:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-      content:
-        application/problem+json:
-          schema:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht429"
-    '500':
-      description: Internal Server Error
-      headers:
-        api-version:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-      content:
-        application/problem+json:
-          schema:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht500"
-    'default':
-      description: Er is een onverwachte fout opgetreden.
-      headers:
-        api-version:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
-      content:
-        application/problem+json:
-          schema:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+    VraagType:
+      type: "string"
+      description: "<body>de type van de vraag</body><body><p>de type van de vraag</p></body><body><p>de\
+        \ type van de vraag</p></body>:\n* `Technische vraag` - Technische vraag\n\
+        * `Mondelinge politieke vraag` - Mondelinge politieke vraag\n* `Schriftelijke\
+        \ politieke vraag` - Schriftelijke politieke vraag"
+      enum:
+      - "Technische vraag"
+      - "Mondelinge politieke vraag"
+      - "Schriftelijke politieke vraag"

--- a/api-specificatie/refimplementatie/openapi.yaml
+++ b/api-specificatie/refimplementatie/openapi.yaml
@@ -1,0 +1,1356 @@
+openapi: 3.0.0
+servers:
+# Added by API Auto Mocking Plugin
+  - description: SwaggerHub API Auto Mocking
+    url: https://virtserver.swaggerhub.com/VNGRealisatie/api/open_raadsinformatie/v1
+info:
+  title: Open Raads- en StatenInformatie
+  description: |
+                Dit is de concept-versie van de API-documentatie voor Open RaadsInformatie. Deze versie is gebaseerd op de ervaringen die opgedaan zijn tijdens het maken van een referentie-implentatie. Met deze specificatie kan een deel van de gegevens die in het informatiemodel beschreven zijn ontsloten worden. Daarnaast is in deze versie een toevoeging gedaan [(zie documentatie)](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) waardoor de API ook JSON-LD compliant is.Vooralsnog wordt er geen centraal context-bestand gepubliceerd, maar de standaard is wel voorbereid op het gebruik van een context bestand."
+  version: "0.9.0"
+  contact:
+    url: https://github.com/VNG-Realisatie/ODS-Open-Raadsinformatie
+  license:
+    name: European Union Public License, version 1.2 (EUPL-1.2)
+    url: https://eupl.eu/1.2/nl/
+paths:
+  /agendapunten/{agendapuntnummer}:
+    get:
+      operationId: GetAgendapunt
+      summary: Raadpleeg agendapunt op unieke identificatie.
+      description: | 
+                    Het bericht dat de JSON/REST API voor het ophalen van gegevens van een agendapunt retourneert."
+      parameters: 
+        - in: path
+          name: agendapuntnummer
+          description: | 
+                        Unieke identificatie van het agendapunt.
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+      responses:
+        '200':
+          description: | 
+                        Zoekactie geslaagd
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/Agendapunt'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/404"
+        '406':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Agendapunten
+    delete:
+      operationId: DelAgendapunt
+      summary: Verwijder agendapunt
+      description: |
+                    Het bericht dat de JSON/REST API voor het verwijderen van agendapunt.
+      parameters: 
+        - in: path
+          name: agendapuntnummer
+          description: | 
+                        Unieke identificatie van het agendapunt.
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+      responses:
+        "204":
+          description: ""
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/404"
+        '406':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+        - Agendapunten
+  /agendapunten:
+    get:
+      operationId: GetAgendapunten
+      description: |
+                    Het bericht dat de JSON/REST API voor het ophalen van een collectie agendapunten retourneert.
+      parameters: 
+        - in: query
+          name: pagina
+          description: |
+                        Een pagina binnen de gepagineerde resultatenset.
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+        - in: query
+          name: agendapuntomschrijving
+          description: |
+                        De omschrijving van het agendapunt.
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/warning"
+            X-Pagination-Page:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
+            X-Pagination-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                type: object
+                properties:
+                  _links:
+                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+                  _embedded:
+                    type: object
+                    properties:
+                      agendapunten:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Agendapunt'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
+        '406':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Agendapunten
+    post:
+      operationId: PostAgendapunt
+      description: |
+                    Registreer een agendapunt.
+      responses:
+        '201':
+          description: ""
+          headers: 
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Agendapunt'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
+        '406':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
+      tags:
+      - Agendapunten
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Agendapunt'
+        required: true
+    put:
+      operationId: PutAgendapunt
+      description: |
+                    Wijzig een bestaand Agendapunt
+      responses:
+        '202':
+          description: ""
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/Agendapunt'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
+        '406':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
+      tags:
+      - Agendapunten
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Agendapunt'
+        required: true
+  /informatieobjecten/{informatieobjectidentificatie}:
+    get:
+      operationId: GetInformatieobject
+      description: |
+                    Het bericht dat de JSON/REST API voor het ophalen van gegevens van een informatieobject retourneert.
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: |
+                        Unieke identificatie van een informatieobject. 
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+      responses:
+        '200':
+          description: |
+                        Zoekactie geslaagd
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/Informatieobject'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/404"
+        '406':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Informatieobjecten
+    delete:
+      operationId: DelInformatieobject
+      description: "Het bericht dat de JSON/REST API voor het verwijderen van informatieobject."
+      parameters: 
+        - in: path
+          name: informatieobjectidentificatie
+          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+      responses:
+        "204":
+          description: ""
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Foutbericht"
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/404"
+        '406':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+        - Informatieobjecten
+  /informatieobjecten:
+    get:
+      operationId: GetInformatieobjecten
+      description: "Het bericht dat de JSON/REST API voor het ophalen van een collectie informatieobjecten retourneert."
+      parameters: 
+        - in: query
+          name: pagina
+          description: "Een pagina binnen de gepagineerde resultatenset."
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+        - in: query
+          name: auteur
+          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creëren van de inhoud van het INFORMATIEOBJECT. Het kan zowel een medewerker of organisatorische eenheid van de zaakbehandelende organisatie betreffen als een externe partij (persoon of organisatie). Het betreft het Dublin Core metadata-element ‘Creator’ met als toelichting: Examples of Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity. Van een ontvangen informatieobject kan de afzender de auteur zijn maar dat kan ook een ander zijn bijvoorbeeld in het geval dat de afzender een document van een derde meestuurt. Indien het informatieobject in een geautomatiseerd proces is vervaardigd, dan wordt als auteur vermeld degene die dat informatieobject ondertekend zou hebben dan wel, bij informatieobjecten waarbij van ondertekening geen sprake is (zoals bijvoorbeeld bij het omzetten van de zaakgegevens naar een duurzaam bewaarbaar informatieobject in pdf), degene die verantwoordelijk is voor de inhoud van het informatieobject vanuit zijn of haar rol bij de zaak (veelal degene in de rol van Zaakcoördinator). De naamgegevens van de auteur zijnde een betrokkene die in een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur niet in een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk persoon of organisatie zijnde de auteur. In het laatste geval verdient het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap wordt uitgeoefend."
+          required: false
+          schema:
+            type: string
+            maxLength: 200
+        - in: query
+          name: bronorganisatie
+          description: "bronorganisatie bronorganisatie Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Het betreft het RSIN (Rechtspersonen en Samenwerkingsverbanden InformatieNummer) zoals dat door de KvK in het NHR aan elk rechtspersoon en samenwerkingsverband is toegekend. Dit identificeert uniek de organisatie, zijnde een rechtspersoon of samenwerkingsverband, dat het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Met het laatste doelen we er op dat bij uitwisseling van een informatieobject tussen samenwerkende organisaties de unieke aanduiding van het informatieobject niet wijzigt mits de ontvangende organisatie geen wijzigingen in het informatieobject aanbrengt. In het laatste geval ontstaat een nieuw informatieobject. Het RSIN staat in het Handelsregister (NHR) en op het daaraan te ontlenen uittreksel. Deze attribuutsoort vormt tezamen met de Informatieobjectidentificatie de unieke aanduiding van een informatieobject voor geheel Nederland. De waarde van dit attribuutsoort wijzigt niet, ook niet indien (de behandeling van) het informatieobject over zou gaan naar een andere organisatie. Er is immers maar één organisatie die het informatieobject gecreëerd of als eerste vastgelegd heeft. De in het NHR voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden."
+          required: false
+          schema:
+            type: integer
+            maximum: 9.99999999E8
+        - in: query
+          name: creatiedatum
+          description: "creatiedatum creatiedatum Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Deze datum verwijst gewoonlijk naar de creatie van het INFORMATIEOBJECT. Het betreft het Dublin Core metadata-element ‘Date’ met als toelichting: Typically, Date will be associated with the creation or availability of the resource. Recommended best practice for encoding the date value is defined in a profile of ISO 8601 (W3CDTF) and includes (among others) dates of the form YYYY-MM-DD. Alle geldige datums gelegen op of voor de huidige datum en tijd"
+          required: false
+          schema:
+            type: string
+            format: date
+        - in: query
+          name: datumingediend
+          description: "De datum waarop het BESLUITVORMINGSSTUK is ingediend"
+          required: false
+          schema:
+            type: string
+            format: date
+        - in: query
+          name: omschrijving
+          description: "De omschrijving van het BESLUITVORMINGSSTUK Dit kan de omschrijving zijn van de MOTIE, het AMENDEMENT of het VOORSTEL"
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: ontvangstdatum
+          description: "ontvangstdatum ontvangstdatum De datum waarop het INFORMATIEOBJECT ontvangen is. De datum waarop het INFORMATIEOBJECT ontvangen is. Het gaat hier om de datum waarop het INFORMATIEOBJECT ontvangen is door de zaakbehandelende organisatie(s), dus niet door een specifieke afdeling of medewerker daarvan. Alle geldige datums gelegen op, voor of na de huidige datum en tijd"
+          required: false
+          schema:
+            type: string
+            format: date
+        - in: query
+          name: taal
+          description: "Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT Het betreft het Dublin Core metadata-element ‘Language’ met als toelichting: Recommended best practice is to use RFC 3066 (RFC3066), which, in conjunction with ISO 639 (ISO639), defines two- and three-letter primary language tags with optional subtags. Examples include “en” or “eng” for English, “akk  for Akkadian, and “en-GB” for English used in the United Kingdom. De Nederlandse taal wordt gecodeerd als “dut”. bij voorkeur ISO 639-2/B"
+          required: false
+          schema:
+            type: string
+            maxLength: 20
+        - in: query
+          name: titel
+          description: "titel titel De naam waaronder het INFORMATIEOBJECT formeel bekend is. De naam waaronder het INFORMATIEOBJECT formeel bekend is. Het betreft het Dublin Core metadata-element ‘Title’ met als toelichting: Typically, Title will be a name by which the resource is formally known. alle alfanumerieke tekens"
+          required: false
+          schema:
+            type: string
+            maxLength: 200
+        - in: query
+          name: toelichting
+          description: "De toelichting op het AMENDEMENT"
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: versie
+          description: "versie versie Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Het gaat hier om een versienummer zoals ‘0.2’ en 1.0’. Ofschoon we er voor gekozen hebben om zowel dit attribuuttype als het attribuuttype Status optioneel te verklaren, ware het aan te bevelen bij elk documemt in ieder geval één van beide attributen van een waarde te voorzien. Nb: De attribuutsoort is in versie 2.0 verplaatst van ENKELVOUDIG INFORMATIEOBJECT naar INFORMATIEOBJECT. Alle alfanumerieke tekens m.u.v. diacrieten"
+          required: false
+          schema:
+            type: string
+            maxLength: 5
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/Informatieobject'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/404"
+        '406':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Informatieobjecten
+    post:
+      operationId: postInformatieobject
+      description: "Registreer een informatieobject."
+      responses:
+        '201':
+          description: ''
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Informatieobject'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/404"
+        '406':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
+      tags:
+      - Informatieobjecten
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Informatieobject'
+        required: true
+    put:
+      operationId: putInformatieobject
+      description: "Wijzig een bestaand Informnatieobject"
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/Informatieobject'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/404"
+        '406':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
+      tags:
+      - Informatieobjecten
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Informatieobject'
+        required: true
+  /vergaderingen:
+    get:
+      operationId: GetVergaderingen
+      description: "Het bericht dat de JSON/REST API voor het ophalen van vergaderingsgegevens retourneert."
+      parameters: 
+        - in: query
+          name: pagina
+          description: "Een pagina binnen de gepagineerde resultatenset."
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/parameters.yaml#/expand"
+        - in: query
+          name: naam
+          description: "De naam van de vergadering"
+          required: false
+          schema:
+            type: string
+            maxLength: 100
+        - in: query
+          name: status
+          description: "De status van de vergadering"
+          required: false
+          schema:
+              $ref: "#/components/schemas/VergaderingStatus"
+        - in: query
+          name: vergaderdatum
+          description: "De datum van de VERGADERING"
+          required: false
+          schema:
+            type: string
+            format: date
+        - in: query
+          name: vergaderingstype
+          description: "De type-aanduiding van de vergadering."
+          required: false
+          schema:
+              $ref: "#/components/schemas/VergaderingsType"
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/warning"
+            X-Pagination-Page:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/X_Pagination_Page"
+            X-Pagination-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                type: object
+                properties:
+                  _links:
+                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+                  _embedded:
+                    type: object
+                    properties:
+                      vergaderingen:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Vergadering'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/404"
+        '406':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Vergaderingen
+    post:
+      operationId: postVergadering
+      description: "Registreer een Vergadering"
+      responses:
+        '201':
+          description: ''
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vergadering'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/404"
+        '406':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
+      tags:
+      - Vergaderingen
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Vergadering'
+        required: true
+    put:
+      operationId: putVergadering
+      description: "Wijzig een bestaand Vergadering"
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/Vergadering' 
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/404"
+        '406':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
+      tags:
+      - Vergaderingen
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Vergadering'
+        required: true
+  /vergaderingen/{vergaderingsidentificatie}:
+    get:
+      operationId: GetVergadering
+      description: "Het bericht dat de JSON/REST API voor het ophalen van vergaderingsgegevens retourneert."
+      parameters: 
+        - in: path
+          name: vergaderingsidentificatie
+          description: "De identificatie een VERGADERING De eerste vier karakter zijn de gemeentecode, gevolgd door een volgnummer van 7 cijfers met voorloopnullen."
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+          example: 1234567890
+      responses:
+        '200':
+          description: "Zoekactie geslaagd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/Vergadering'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/404"
+        '406':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+      - Vergaderingen
+    delete:
+      operationId: DelVergadering
+      description: "Het bericht dat de JSON/REST API voor het verwijderen van een Vergadering."
+      parameters: 
+        - in: path
+          name: vergaderingsidentificatie
+          description: "De identificatie een VERGADERING De eerste vier karakter zijn de gemeentecode, gevolgd door een volgnummer van 7 cijfers met voorloopnullen."
+          required: true
+          schema:
+            type: string
+            maxLength: 10
+          example: 1234567890
+      responses:
+        "204":
+          description: ""
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Foutbericht"
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/404"
+        '406':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
+      tags: 
+        - Vergaderingen
+components:
+  schemas:
+    Agendapunt:
+      type: "object"
+      description: "Een onderdeel van de agenda dat als één geheel wordt behandeld.\
+        \ Een AGENDAPUNT kan weer onderverdeeld zijn naar subAGENDAPUNTen."
+      required:
+      - "agendapuntnummer"
+      - "indicatieHamerstuk"
+      - "indicatorBehandeld"
+      - "indicatorBesloten"
+      properties:
+        "@context":
+          type: string
+          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
+        "@id":
+          type: string
+          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
+        "@type":
+          type: string
+          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
+        agendapuntKenmerk:
+          type: "string"
+          title: "Agendapunt kenmerk"
+          description: "De weergave van het Agendapuntvolgnummer op de agenda. Dit\
+            \ is de letterlijke volgorde van een Agendapunt wordt bij gehouden d.m.v.\
+            \ attribuut 'Agendapuntvolgnummer'. Hoe het Agendapunt getoond wordt op\
+            \ de Agenda wordt beschreven met attribuut 'Agendapunt kenmerk'."
+          maxLength: 20
+        agendapuntnummer:
+          type: "string"
+          title: "Agendapuntnummer"
+          description: "Het nummer van het agendapunt op de agenda."
+          maxLength: 10
+          minLength: 1
+        agendapuntOmschrijving:
+          type: "string"
+          title: "Agendapunt omschrijving"
+          description: "De omschrijving van het agendapunt"
+        agendapuntvolgnummer:
+          type: "string"
+          title: "Agendapuntvolgnummer"
+          description: "Dit is het volgnummer van het AGENDAPUNT tijdens de vergadering.\
+            \ Dit is de letterlijke volgorde en zegt niets over hoe dit volgnummer\
+            \ getoond wordt. Hoe het Agendapunt getoond wordt op de Agenda wordt beschreven\
+            \ met attribuut 'Agendapunt kenmerk'."
+          maxLength: 3
+        eindtijd:
+          type: "string"
+          title: "Eindtijd"
+          description: "De datum en tijdstip waarop de behandeling van de agendapunt\
+            \ is geëindigd Moet voor komen als Starttijd voorkomt"
+        geplandAgendapuntvolgnummer:
+          type: "string"
+          title: "Gepland agendapuntvolgnummer"
+          description: "Dit is het geplande volgnummer van het AGENDAPUNT van een\
+            \ vergadering."
+          maxLength: 10
+        geplandeEindtijd:
+          type: "string"
+          title: "Geplande eindtijd"
+          description: "De geplande datum en tijdstip waarop de behandeling van de\
+            \ agendapunt eindigt"
+        geplandeStarttijd:
+          type: "string"
+          title: "Geplande starttijd"
+          description: "De geplande datum en tijdstip waarop de behandeling van de\
+            \ agendapunt start"
+        indicatieHamerstuk:
+          type: "boolean"
+          title: "Indicatie hamerstuk"
+          description: ""
+          example: "true"
+        indicatorBehandeld:
+          type: "boolean"
+          title: "Indicator behandeld"
+          description: "Indicator geeft aan of het AGENDAPUNT is behandeld tijdens\
+            \ de VERGADERING. Is eventueel af te leiden als Starttijd en/of Eindtijd\
+            \ zijn ingevuld defaultwaarde = nee"
+        indicatorBesloten:
+          type: "boolean"
+          title: "Indicator besloten"
+          description: "Indicator of een AGENDAPUNT besloten wordt behandeld defaultwaarde\
+            \ = nee"
+        starttijd:
+          type: "string"
+          title: "Starttijd"
+          description: "De datum en tijdstip waarop de behandeling van de agendapunt\
+            \ is gestart"
+        _links:
+          $ref: "#/components/schemas/Agendapunt_links"
+    Vergadering:
+      type: "object"
+      description: "Een VERGADERING is een bijeenkomst van meerdere mensen die met\
+        \ elkaar spreken en/of afspraken maken over onderwerpen die op de agenda staan."
+      required:
+      - "vergaderingsidentificatie"
+      - "vergaderingstype"
+      properties:
+        "@context":
+          type: string
+          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
+        "@id":
+          type: string
+          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
+        "@type":
+          type: string
+          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
+        aanvangVergadering:
+          type: "string"
+          title: "Aanvang vergadering"
+          description: "De datum en tijdstip waarop de vergadering is gestart Komt\
+            \ zeker voor als Einde vergadering ook is ingevuld"
+          example: "2017-02-10T18:25:00:000Z"
+        audioLink:
+          type: "string"
+          title: "Audio link"
+          description: "De link naar de audio opname van de VERGADERING"
+          format: "uri"
+          example: "https://www.voorbeeldgemeente.nl/audio/link"
+        eindeVergadering:
+          type: "string"
+          title: "Einde vergadering"
+          description: "De datum en tijdstip waarop de vergadering is geëindigd"
+          example: "2017-02-10T21:12:00:000Z"
+        geplandeAanvangVergadering:
+          type: "string"
+          title: "Geplande aanvang vergadering"
+          description: "De geplande datum en tijdstip waarop de vergadering start"
+          example: "2017-02-09T18:25:00:000Z"
+        geplandeEindeVergadering:
+          type: "string"
+          title: "Geplande einde vergadering"
+          description: "De geplande datum en tijdstip waarop de vergadering eindigt"
+          example: "2017-02-09T21:25:00:000Z"
+        geplandeVergaderdatum:
+          type: "string"
+          title: "Geplande vergaderdatum"
+          description: "De geplande datum van de VERGADERING"
+          format: "date"
+          example: "2017-02-09"
+        locatie:
+          type: "string"
+          title: "Locatie"
+          description: "Omschrijving van de locatie waar de vergadering wordt gehouden"
+          maxLength: 100
+          example: "Raadszaal, Stadskantoor, Overtoom 2"
+        naam:
+          type: "string"
+          title: "Naam"
+          description: "De naam van de vergadering"
+          maxLength: 100
+          example: "Raadsvergadering"
+        status:
+          $ref: "#/components/schemas/VergaderingStatus"
+        vergaderdatum:
+          type: "string"
+          title: "Vergaderdatum"
+          description: "De datum van de VERGADERING"
+          format: "date"
+          example: "2017-02-10"
+        vergaderingsidentificatie:
+          type: "string"
+          title: "Vergaderingsidentificatie"
+          description: "De identificatie een VERGADERING De eerste vier karakter zijn\
+            \ de gemeentecode, gevolgd door een volgnummer van 7 cijfers met voorloopnullen."
+          maxLength: 10
+          minLength: 1
+          example: "1234567890"
+        vergaderingstype:
+          $ref: "#/components/schemas/VergaderingsType"
+        vergaderToelichting:
+          type: "string"
+          title: "Vergader toelichting"
+          description: "De toelichting of nadere omschrijving van de vergadering"
+          example: "Regulier geplande raadsvergadering van mei"
+        videoLink:
+          type: "string"
+          title: "Video link"
+          description: "De link naar de video opname van de VERGADERING"
+          format: "uri"
+          example: "https://www.voorbeeldgemeente.nl/video/link"
+        _links:
+          $ref: "#/components/schemas/Vergadering_links"
+    Informatieobject:
+      type: "object"
+      description: | 
+                    Deze resource correspondeert met het enkelvoudig informatieobject en al zijn specialisaties. 
+                    Voor de implementatie zijn alle objecttype die onder het informatieobject voorkomen samengevoegd in deze resource. 
+      required:
+      - "auteur"
+      - "bronorganisatie"
+      - "creatiedatum"
+      - "informatieobjectidentificatie"
+      - "titel"
+      - "informatieobjecttype"
+      properties:
+        "@context":
+          type: string
+          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
+        "@id":
+          type: string
+          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
+        "@type":
+          type: string
+          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
+        informatieobjectType: 
+          $ref: "#/components/schemas/InformatieobjecttypeEnum"
+        auteur:
+          type: "string"
+          title: "Auteur"
+          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk\
+            \ is voor het creëren van de inhoud van het INFORMATIEOBJECT. Het kan\
+            \ zowel een medewerker of organisatorische eenheid van de zaakbehandelende\
+            \ organisatie betreffen als een externe partij (persoon of organisatie).\
+            \ Het betreft het Dublin Core metadata-element ‘Creator’ met als toelichting:\
+            \ Examples of Creator include a person, an organization, or a service.\
+            \ Typically, the name of a Creator should be used to indicate the entity.\
+            \ Van een ontvangen informatieobject kan de afzender de auteur zijn maar\
+            \ dat kan ook een ander zijn bijvoorbeeld in het geval dat de afzender\
+            \ een document van een derde meestuurt. Indien het informatieobject in\
+            \ een geautomatiseerd proces is vervaardigd, dan wordt als auteur vermeld\
+            \ degene die dat informatieobject ondertekend zou hebben dan wel, bij\
+            \ informatieobjecten waarbij van ondertekening geen sprake is (zoals bijvoorbeeld\
+            \ bij het omzetten van de zaakgegevens naar een duurzaam bewaarbaar informatieobject\
+            \ in pdf), degene die verantwoordelijk is voor de inhoud van het informatieobject\
+            \ vanuit zijn of haar rol bij de zaak (veelal degene in de rol van Zaakcoö\
+            rdinator). De naamgegevens van de auteur zijnde een betrokkene die in\
+            \ een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur niet in\
+            \ een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk\
+            \ persoon of organisatie zijnde de auteur. In het laatste geval verdient\
+            \ het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap\
+            \ wordt uitgeoefend."
+          maxLength: 200
+          minLength: 1
+        bronorganisatie:
+          type: "integer"
+          title: "Bronorganisatie"
+          description: "bronorganisatie bronorganisatie Het RSIN van de Niet-natuurlijk\
+            \ persoon zijnde de organisatie die het informatieobject heeft gecreë\
+            erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd.\
+            \ Het betreft het RSIN (Rechtspersonen en Samenwerkingsverbanden InformatieNummer)\
+            \ zoals dat door de KvK in het NHR aan elk rechtspersoon en samenwerkingsverband\
+            \ is toegekend. Dit identificeert uniek de organisatie, zijnde een rechtspersoon\
+            \ of samenwerkingsverband, dat het informatieobject heeft gecreëerd of\
+            \ heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd.\
+            \ Met het laatste doelen we er op dat bij uitwisseling van een informatieobject\
+            \ tussen samenwerkende organisaties de unieke aanduiding van het informatieobject\
+            \ niet wijzigt mits de ontvangende organisatie geen wijzigingen in het\
+            \ informatieobject aanbrengt. In het laatste geval ontstaat een nieuw\
+            \ informatieobject. Het RSIN staat in het Handelsregister (NHR) en op\
+            \ het daaraan te ontlenen uittreksel. Deze attribuutsoort vormt tezamen\
+            \ met de Informatieobjectidentificatie de unieke aanduiding van een informatieobject\
+            \ voor geheel Nederland. De waarde van dit attribuutsoort wijzigt niet,\
+            \ ook niet indien (de behandeling van) het informatieobject over zou gaan\
+            \ naar een andere organisatie. Er is immers maar één organisatie die het\
+            \ informatieobject gecreëerd of als eerste vastgelegd heeft. De in het\
+            \ NHR voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden."
+          maximum: 9.99999999E8
+        creatiedatum:
+          type: "string"
+          title: "Creatiedatum"
+          description: "creatiedatum creatiedatum Een datum of een gebeurtenis in\
+            \ de levenscyclus van het INFORMATIEOBJECT. Deze datum verwijst gewoonlijk\
+            \ naar de creatie van het INFORMATIEOBJECT. Het betreft het Dublin Core\
+            \ metadata-element ‘Date’ met als toelichting: Typically, Date will be\
+            \ associated with the creation or availability of the resource. Recommended\
+            \ best practice for encoding the date value is defined in a profile of\
+            \ ISO 8601 (W3CDTF) and includes (among others) dates of the form YYYY-MM-DD.\
+            \ Alle geldige datums gelegen op of voor de huidige datum en tijd"
+          format: "date"
+        informatieobjectidentificatie:
+          type: "string"
+          title: "Informatieobjectidentificatie"
+          description: "informatieobjectidentificatie informatieobjectidentificatie\
+            \ Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT.\
+            \ Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers\
+            \ en/of leestekens, dat het informatieobject uniek identificeert binnen\
+            \ de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen\
+            \ en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven\
+            \ context’). Door combinatie met het RSIN van die organisatie, als waarde\
+            \ van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland\
+            \ unieke aanduiding van informatieobjecten verkregen. Het betreft het\
+            \ Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended\
+            \ best practice is to identify the resource by means of a string or number\
+            \ conforming to a formal identification system. Formal identification\
+            \ systems include but are not limited to the Uniform Resource Identifier\
+            \ (URI) (including the Uniform Resource Locator (URL)), the Digital Object\
+            \ Identifier (DOI), and the International Standard Book Number (ISBN).\
+            \ Alle alfanumerieke tekens m.u.v. diacrieten"
+          maxLength: 40
+          minLength: 1
+        ontvangstdatum:
+          type: "string"
+          title: "Ontvangstdatum"
+          description: "ontvangstdatum ontvangstdatum De datum waarop het INFORMATIEOBJECT\
+            \ ontvangen is. Het gaat hier om de datum waarop het INFORMATIEOBJECT\
+            \ ontvangen is door de zaakbehandelende organisatie(s), dus niet door\
+            \ een specifieke afdeling of medewerker daarvan. Alle geldige datums gelegen\
+            \ op, voor of na de huidige datum en tijd"
+          format: "date"
+        titel:
+          type: "string"
+          title: "Titel"
+          description: "titel titel De naam waaronder het INFORMATIEOBJECT formeel\
+            \ bekend is. Het betreft het Dublin Core metadata-element ‘Title’ met\
+            \ als toelichting: Typically, Title will be a name by which the resource\
+            \ is formally known. alle alfanumerieke tekens"
+          maxLength: 200
+          minLength: 1
+        versie:
+          type: "string"
+          title: "Versie"
+          description: "versie versie Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT\
+            \ Het gaat hier om een versienummer zoals ‘0.2’ en 1.0’. Ofschoon we er\
+            \ voor gekozen hebben om zowel dit attribuuttype als het attribuuttype\
+            \ Status optioneel te verklaren, ware het aan te bevelen bij elk documemt\
+            \ in ieder geval één van beide attributen van een waarde te voorzien.\
+            \ Nb: De attribuutsoort is in versie 2.0 verplaatst van ENKELVOUDIG INFORMATIEOBJECT\
+            \ naar INFORMATIEOBJECT. Alle alfanumerieke tekens m.u.v. diacrieten"
+          maxLength: 5
+        bestandsomvang:
+          type: "integer"
+          title: "Bestandsomvang"
+          description: "Ruimtebeslag op het digitale opslagmedium waarin het fysieke\
+            \ bestand met de inhoud van het INFORMATIEOBJECT is vastgelegd Ofschoon\
+            \ dit een afleidbaar gegeven is, aangezien het af te leiden is uit het\
+            \ fysieke bestand, is er voor gekozen dit gegeven toch op te nemen.\
+            \ Het kunnen afleiden van dit gegeven veronderstelt dat het bestand\
+            \ zelf beschikbaar is om dit gegeven af te kunnen leiden en dat functionaliteiten\
+            \ hiervoor beschikbaar zijn. Hiervan is niet altijd sprake. Omvang van\
+            \ het fysieke bestand in aantal bytes."
+          maximum: 9.999999999E9
+        formaat:
+          type: "string"
+          title: "Formaat"
+          description: "De code voor de wijze waarop de inhoud van het ENKELVOUDIG\
+            \ INFORMATIEOBJECT is vastgelegd in een computerbestand. Het gaat hier\
+            \ om de bestandsoort van het enkelvoudig informatieobject. Het betreft\
+            \ het Dublin Core metadata-element ‘Format’ met als toelichting: Typically,\
+            \ Format will include the media-type or dimensions of the resource.\
+            \ Format may be used to identify the software, hardware, or other equipment\
+            \ needed to display or operate the resource. Examples of dimensions\
+            \ include size and duration. Recommended best practice is to select\
+            \ a value from a controlled vocabulary (for example, the list of Internet\
+            \ Media Types (MIME) defining computer media formats). Aangezien, bij\
+            \ bijvoorbeeld omzetting naar een duurzaam bewaarbaar informatieobject,\
+            \ het formaat kan wijzigen kent deze attribuutsoort historie. MIME-types\
+            \ en –subtypes conform IANA"
+          minLength: 1
+        inhoud:
+          type: "string"
+          title: "Inhoud"
+          description: "Datgene wat in een ENKELVOUDIG INFORMATIEOBJECT wordt meegedeeld.\
+            \ Het gaat hier om de inhoud of content van het ENKELVOUDIG INFORMATIEOBJECT\
+            \ (in het spraakgebruik ‘de tekst van het document’) in het formaat\
+            \ zoals vastgelegd in Formaat. Veelal gaat het om de tekst van een ENKELVOUDIG\
+            \ INFORMATIEOBJECT (bijvoorbeeld in pdf-formaat). Het kan bijvoorbeeld\
+            \ ook een afbeelding (in bijvoorbeeld jpg-formaat) of een kaart (in\
+            \ bijvoorbeeld gmlformaat) betreffen. De mogelijkheid bestaat dat de\
+            \ inhoud in een (al dan niet separaat) bestand wordt uitgewisseld of\
+            \ dat er alleen verwezen wordt naar de locatie waar zich de inhoud bevindt.\
+            \ Hiertoe zijn de attribuutsoorten Bestandsnaam respectievelijk Link\
+            \ opgenomen. De content (data) van het enkelvoudig informatieobject\
+            \ in het formaat zoals gespecificeerd met de attribuutsoort 'Formaat'."
+        link:
+          type: "string"
+          title: "Link"
+          description: "De URL waarmee de inhoud van het INFORMATIEOBJECT op te\
+            \ vragen is. Vanwege vooral technische belemmeringen kan het voorkomen\
+            \ dat de attribuutsoort Inhoud geen waarde heeft d.w.z. dat de inhoud\
+            \ van het informatieobject ('het document' in het spraakgebruik) niet\
+            \ uitgewisseld wordt. Het attribuutsoort Link verwijst dan naar de locatie\
+            \ waar de inhoud van het informatieobject ('het document') zich bevindt\
+            \ en schept de mogelijkheid de Inhoud ('het document') op te vragen.\
+            \ Een meer structurelere wijze om de Inhoud op te vragen, is uiteraard\
+            \ met behulp van de Identificatie."
+          format: "uri"
+        taal:
+          type: "string"
+          title: "Taal"
+          description: "Een taal van de intellectuele inhoud van het ENKELVOUDIG\
+            \ INFORMATIEOBJECT Het betreft het Dublin Core metadata-element ‘Language’\
+            \ met als toelichting: Recommended best practice is to use RFC 3066\
+            \ (RFC3066), which, in conjunction with ISO 639 (ISO639), defines two-\
+            \ and three-letter primary language tags with optional subtags. Examples\
+            \ include “en” or “eng” for English, “akk` for Akkadian, and “en-GB”\
+            \ for English used in the United Kingdom. De Nederlandse taal wordt\
+            \ gecodeerd als “dut”. bij voorkeur ISO 639-2/B"
+          maxLength: 20
+          minLength: 1
+        datumIngediend:
+          type: "string"
+          title: "Datum ingediend"
+          description: "De datum waarop het BESLUITVORMINGSSTUK is ingediend"
+          format: "date"
+        omschrijving:
+          type: "string"
+          title: "Omschrijving"
+          description: "De omschrijving van het BESLUITVORMINGSSTUK Dit kan de omschrijving\
+            \ zijn van de MOTIE, het AMENDEMENT of het VOORSTEL"
+        typeVraag:
+          $ref: "#/components/schemas/VraagType"
+        typeMotie:
+          $ref: "#/components/schemas/MotieType"
+        _links:
+          $ref: "#/components/schemas/InformatieobjectLinks"
+    Agendapunt_links:
+      type: "object"
+      properties:
+        "@id":
+          type: string
+          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
+        "@context":
+            type: string
+            format: "uri"
+            example: "href: @id "
+            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
+        self:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+        informatieobjecten:
+          title: "heeftAlsBijlage"
+          type: "array"
+          description: "Een AGENDAPUNT kan één of meerdere VERGADERSTUKken als bijlage\
+            \ hebben"
+          items:
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+        agendapunten:
+          title: "heeftAlsSubagendapunt"
+          type: "array"
+          description: "Een AGENDAPUNT kan uit één of meer subAGENDAPUNTen en een\
+            \ subAGENDAPUNT kan weer bestaan uit één of meer sub(sub)AGENDAPUNTen."
+          items:
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+        vergaderingen:
+          title: "wordtBehandeldTijdens"
+          type: "object"
+          description: "Een AGENDAPUNT wordt behandeld tijdens een VERGADERING."
+          properties:
+            href:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+    InformatieobjectLinks:
+      type: "object"
+      properties:
+        "@id":
+          type: string
+          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
+        "@context":
+            type: string
+            format: "uri"
+            example: "href: @id "
+            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
+        self:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+        hoortBijInformatieobject:
+          title: "heeftBetrekkingOp"
+          type: "object"
+          description: | 
+                        Een informatieobject heeft een relatie met een ander informatieobject. Bijvoorbeeld Een subamendement is een wijzigingsvoorstel voor een amendement en een antwoord hoort bij een vraag en een amendement heeft betrekking op een voorstel.
+          properties:
+            href:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Href"
+    Vergadering_links:
+      type: "object"
+      properties:
+        "@id":
+          type: string
+          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
+        "@context":
+            type: string
+            format: "uri"
+            example: "href: @id "
+            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
+        self:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+        aanwezigeDeelnemers:
+          title: "isAanwezigBij"
+          type: "array"
+          description: "persoon met een functie neemt deel aan een vergadering"
+          items:
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+        agendapunten:
+          title: "wordtBehandeldTijdens"
+          type: "array"
+          description: "Een AGENDAPUNT wordt behandeld tijdens een VERGADERING."
+          items:
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+        informatieobjecten:
+          title: "heeftAlsBijlage"
+          type: "array"
+          description: "Een VERGADERING kan ook één of meer VERGADERSTUKKEN als bijlage\
+            \ hebben. Dit zijn bijvoorbeeld de notulen en de besluitenlijst van de\
+            \ vorige VERGADERING"
+          items:
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+        vergaderingen:
+          title: "heeftAlsDeelvergadering"
+          type: "array"
+          description: "Een VERGADERING kan uit één of meerdere deel-VERGADERINGen bestaan"
+          items:
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+    VraagType:
+      type: "string"
+      description: "de type van de vraag de type van de vraagde type van de vraag:\n\
+        * `Technische vraag` - Technische vraag\n* `Mondelinge politieke vraag` -\
+        \ Mondelinge politieke vraag\n* `Schriftelijke politieke vraag` - Schriftelijke\
+        \ politieke vraag"
+      enum:
+      - "Technische vraag"
+      - "Mondelinge politieke vraag"
+      - "Schriftelijke politieke vraag"
+    VergaderingStatus:
+      type: "string"
+      description: "duiding van de statussen van een VERGADERING:\n* `0` - Gepland\n\
+        * `1` - Gehouden\n* `2` - Geannuleerd"
+      enum:
+      - "0"
+      - "1"
+      - "2"
+    MotieType:
+      type: "string"
+      description: "duiding van het type van een MOTIE:\n* `R` - Voorstel\n* `A` -\
+        \ Afkeuring\n* `T` - Treurnis\n* `W` - Wantrouwen\n* `V` - Vreemd\n* `O` -\
+        \ Overig"
+      enum:
+      - "R"
+      - "A"
+      - "T"
+      - "W"
+      - "V"
+      - "O"
+    InformatieobjecttypeEnum:
+      type: "string"
+      description: "Het type van een informatieobject."
+      enum:
+      - "Besluitvormingsstuk"
+      - "Antwoord"
+      - "Ingekomenstuk"
+      - "Mededeling"
+      - "Motie"
+      - "Toezegging"
+      - "Voorstellen"
+      - "Vragen"
+    VergaderingsType:
+      type: "string"
+      description: "De mogelijke typen van een VERGADERING behorende bij de gemeenteraad:"
+      enum:
+      - "Raadsvergadering"
+      - "Presidium"
+      - "Commissievergadering"
+      - "Statenvergadering"

--- a/api-specificatie/refimplementatie/openapi.yaml
+++ b/api-specificatie/refimplementatie/openapi.yaml
@@ -107,6 +107,7 @@ paths:
   /agendapunten:
     get:
       operationId: GetAgendapunten
+      summary: Zoek agendapunten
       description: |
                     Het bericht dat de JSON/REST API voor het ophalen van een collectie agendapunten retourneert.
       parameters: 
@@ -177,6 +178,7 @@ paths:
       - Agendapunten
     post:
       operationId: PostAgendapunt
+      summary: Opslaan agendapunt
       description: |
                     Registreer een agendapunt.
       responses:
@@ -215,6 +217,7 @@ paths:
         required: true
     put:
       operationId: PutAgendapunt
+      summary: Wijzig agendapunt
       description: |
                     Wijzig een bestaand Agendapunt
       responses:
@@ -256,6 +259,7 @@ paths:
   /informatieobjecten/{informatieobjectidentificatie}:
     get:
       operationId: GetInformatieobject
+      summary: Raadpleeg informatieobject
       description: |
                     Het bericht dat de JSON/REST API voor het ophalen van gegevens van een informatieobject retourneert.
       parameters: 
@@ -308,11 +312,14 @@ paths:
       - Informatieobjecten
     delete:
       operationId: DelInformatieobject
-      description: "Het bericht dat de JSON/REST API voor het verwijderen van informatieobject."
+      summary: Verwijder informatieobject
+      description: |
+                    Het bericht dat de JSON/REST API voor het verwijderen van informatieobject.
       parameters: 
         - in: path
           name: informatieobjectidentificatie
-          description: "informatieobjectidentificatie informatieobjectidentificatie Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers en/of leestekens, dat het informatieobject uniek identificeert binnen de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven context’). Door combinatie met het RSIN van die organisatie, als waarde van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland unieke aanduiding van informatieobjecten verkregen. Het betreft het Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended best practice is to identify the resource by means of a string or number conforming to a formal identification system. Formal identification systems include but are not limited to the Uniform Resource Identifier (URI) (including the Uniform Resource Locator (URL)), the Digital Object Identifier (DOI), and the International Standard Book Number (ISBN). Alle alfanumerieke tekens m.u.v. diacrieten"
+          description: |
+                        Unieke identificatie van het informatieobject. 
           required: true
           schema:
             type: string
@@ -350,7 +357,9 @@ paths:
   /informatieobjecten:
     get:
       operationId: GetInformatieobjecten
-      description: "Het bericht dat de JSON/REST API voor het ophalen van een collectie informatieobjecten retourneert."
+      summary: Zoek informatieobjecten
+      description: |
+                    Het bericht dat de JSON/REST API voor het ophalen van een collectie informatieobjecten retourneert.
       parameters: 
         - in: query
           name: pagina
@@ -361,75 +370,79 @@ paths:
             minimum: 1
         - in: query
           name: auteur
-          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creëren van de inhoud van het INFORMATIEOBJECT. Het kan zowel een medewerker of organisatorische eenheid van de zaakbehandelende organisatie betreffen als een externe partij (persoon of organisatie). Het betreft het Dublin Core metadata-element ‘Creator’ met als toelichting: Examples of Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity. Van een ontvangen informatieobject kan de afzender de auteur zijn maar dat kan ook een ander zijn bijvoorbeeld in het geval dat de afzender een document van een derde meestuurt. Indien het informatieobject in een geautomatiseerd proces is vervaardigd, dan wordt als auteur vermeld degene die dat informatieobject ondertekend zou hebben dan wel, bij informatieobjecten waarbij van ondertekening geen sprake is (zoals bijvoorbeeld bij het omzetten van de zaakgegevens naar een duurzaam bewaarbaar informatieobject in pdf), degene die verantwoordelijk is voor de inhoud van het informatieobject vanuit zijn of haar rol bij de zaak (veelal degene in de rol van Zaakcoördinator). De naamgegevens van de auteur zijnde een betrokkene die in een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur niet in een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk persoon of organisatie zijnde de auteur. In het laatste geval verdient het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap wordt uitgeoefend."
+          description: | 
+                        De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creëren van de inhoud van het INFORMATIEOBJECT.
           required: false
           schema:
             type: string
             maxLength: 200
         - in: query
           name: bronorganisatie
-          description: "bronorganisatie bronorganisatie Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Het betreft het RSIN (Rechtspersonen en Samenwerkingsverbanden InformatieNummer) zoals dat door de KvK in het NHR aan elk rechtspersoon en samenwerkingsverband is toegekend. Dit identificeert uniek de organisatie, zijnde een rechtspersoon of samenwerkingsverband, dat het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. Met het laatste doelen we er op dat bij uitwisseling van een informatieobject tussen samenwerkende organisaties de unieke aanduiding van het informatieobject niet wijzigt mits de ontvangende organisatie geen wijzigingen in het informatieobject aanbrengt. In het laatste geval ontstaat een nieuw informatieobject. Het RSIN staat in het Handelsregister (NHR) en op het daaraan te ontlenen uittreksel. Deze attribuutsoort vormt tezamen met de Informatieobjectidentificatie de unieke aanduiding van een informatieobject voor geheel Nederland. De waarde van dit attribuutsoort wijzigt niet, ook niet indien (de behandeling van) het informatieobject over zou gaan naar een andere organisatie. Er is immers maar één organisatie die het informatieobject gecreëerd of als eerste vastgelegd heeft. De in het NHR voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden."
+          description: |
+                        Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. 
           required: false
           schema:
             type: integer
             maximum: 9.99999999E8
         - in: query
           name: creatiedatum
-          description: "creatiedatum creatiedatum Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. Deze datum verwijst gewoonlijk naar de creatie van het INFORMATIEOBJECT. Het betreft het Dublin Core metadata-element ‘Date’ met als toelichting: Typically, Date will be associated with the creation or availability of the resource. Recommended best practice for encoding the date value is defined in a profile of ISO 8601 (W3CDTF) and includes (among others) dates of the form YYYY-MM-DD. Alle geldige datums gelegen op of voor de huidige datum en tijd"
+          description: |
+                        Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT.
           required: false
           schema:
             type: string
             format: date
         - in: query
           name: datumingediend
-          description: "De datum waarop het BESLUITVORMINGSSTUK is ingediend"
+          description: |
+                        De datum waarop het informatieobject is ingediend"
           required: false
           schema:
             type: string
             format: date
         - in: query
           name: omschrijving
-          description: "De omschrijving van het BESLUITVORMINGSSTUK Dit kan de omschrijving zijn van de MOTIE, het AMENDEMENT of het VOORSTEL"
+          description: |
+                        De omschrijving van het informatieobject
           required: false
           schema:
             type: string
         - in: query
           name: ontvangstdatum
-          description: "ontvangstdatum ontvangstdatum De datum waarop het INFORMATIEOBJECT ontvangen is. De datum waarop het INFORMATIEOBJECT ontvangen is. Het gaat hier om de datum waarop het INFORMATIEOBJECT ontvangen is door de zaakbehandelende organisatie(s), dus niet door een specifieke afdeling of medewerker daarvan. Alle geldige datums gelegen op, voor of na de huidige datum en tijd"
+          description: |
+                        De datum waarop het INFORMATIEOBJECT ontvangen is. 
           required: false
           schema:
             type: string
             format: date
         - in: query
           name: taal
-          description: "Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT Het betreft het Dublin Core metadata-element ‘Language’ met als toelichting: Recommended best practice is to use RFC 3066 (RFC3066), which, in conjunction with ISO 639 (ISO639), defines two- and three-letter primary language tags with optional subtags. Examples include “en” or “eng” for English, “akk  for Akkadian, and “en-GB” for English used in the United Kingdom. De Nederlandse taal wordt gecodeerd als “dut”. bij voorkeur ISO 639-2/B"
+          description: |
+                        Een taal van de intellectuele inhoud van het informatieobject.
           required: false
           schema:
             type: string
             maxLength: 20
         - in: query
           name: titel
-          description: "titel titel De naam waaronder het INFORMATIEOBJECT formeel bekend is. De naam waaronder het INFORMATIEOBJECT formeel bekend is. Het betreft het Dublin Core metadata-element ‘Title’ met als toelichting: Typically, Title will be a name by which the resource is formally known. alle alfanumerieke tekens"
+          description: |
+                        De naam waaronder het INFORMATIEOBJECT formeel bekend is. 
           required: false
           schema:
             type: string
             maxLength: 200
         - in: query
-          name: toelichting
-          description: "De toelichting op het AMENDEMENT"
-          required: false
-          schema:
-            type: string
-        - in: query
           name: versie
-          description: "versie versie Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT Het gaat hier om een versienummer zoals ‘0.2’ en 1.0’. Ofschoon we er voor gekozen hebben om zowel dit attribuuttype als het attribuuttype Status optioneel te verklaren, ware het aan te bevelen bij elk documemt in ieder geval één van beide attributen van een waarde te voorzien. Nb: De attribuutsoort is in versie 2.0 verplaatst van ENKELVOUDIG INFORMATIEOBJECT naar INFORMATIEOBJECT. Alle alfanumerieke tekens m.u.v. diacrieten"
+          description: |
+                        Aanduiding van de bewerkingsfase van het informatieobject
           required: false
           schema:
             type: string
             maxLength: 5
       responses:
         '200':
-          description: "Zoekactie geslaagd"
+          description: |
+                        Zoekactie geslaagd
           headers:
             api-version:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
@@ -460,11 +473,13 @@ paths:
       tags: 
       - Informatieobjecten
     post:
-      operationId: postInformatieobject
-      description: "Registreer een informatieobject."
+      operationId: PostInformatieobject
+      summary: Opslaan informatieobject
+      description: |
+                    Registreer een informatieobject.
       responses:
         '201':
-          description: ''
+          description: ""
           headers:
             api-version:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
@@ -499,11 +514,14 @@ paths:
               $ref: '#/components/schemas/Informatieobject'
         required: true
     put:
-      operationId: putInformatieobject
-      description: "Wijzig een bestaand Informnatieobject"
+      operationId: PutInformatieobject
+      summary: Wijzig informatieobject
+      description: |    
+                    Wijzig een bestaand Informnatieobject"
       responses:
         '200':
-          description: "Zoekactie geslaagd"
+          description: |
+                        Zoekactie geslaagd
           headers:
             api-version:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
@@ -542,11 +560,13 @@ paths:
   /vergaderingen:
     get:
       operationId: GetVergaderingen
-      description: "Het bericht dat de JSON/REST API voor het ophalen van vergaderingsgegevens retourneert."
+      description: |
+                    Het bericht dat de JSON/REST API voor het ophalen van vergaderingsgegevens retourneert.
       parameters: 
         - in: query
           name: pagina
-          description: "Een pagina binnen de gepagineerde resultatenset."
+          description: |
+                        Een pagina binnen de gepagineerde resultatenset.
           required: false
           schema:
             type: integer
@@ -554,33 +574,38 @@ paths:
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/parameters.yaml#/expand"
         - in: query
           name: naam
-          description: "De naam van de vergadering"
+          description: |
+                        De naam van de vergadering
           required: false
           schema:
             type: string
             maxLength: 100
         - in: query
           name: status
-          description: "De status van de vergadering"
+          description: |
+                        De status van de vergadering
           required: false
           schema:
               $ref: "#/components/schemas/VergaderingStatus"
         - in: query
           name: vergaderdatum
-          description: "De datum van de VERGADERING"
+          description: |
+                        De datum van de vergadering
           required: false
           schema:
             type: string
             format: date
         - in: query
           name: vergaderingstype
-          description: "De type-aanduiding van de vergadering."
+          description: |
+                        De type-aanduiding van de vergadering.
           required: false
           schema:
               $ref: "#/components/schemas/VergaderingsType"
       responses:
         '200':
-          description: "Zoekactie geslaagd"
+          description: |
+                        Zoekactie geslaagd
           headers:
             api-version:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
@@ -632,7 +657,8 @@ paths:
       - Vergaderingen
     post:
       operationId: postVergadering
-      description: "Registreer een Vergadering"
+      description: |
+                    Registreer een Vergadering
       responses:
         '201':
           description: ''
@@ -670,8 +696,9 @@ paths:
               $ref: '#/components/schemas/Vergadering'
         required: true
     put:
-      operationId: putVergadering
-      description: "Wijzig een bestaand Vergadering"
+      operationId: PutVergadering
+      description: |
+                    Wijzig een bestaand Vergadering"
       responses:
         '200':
           description: "Zoekactie geslaagd"
@@ -713,11 +740,13 @@ paths:
   /vergaderingen/{vergaderingsidentificatie}:
     get:
       operationId: GetVergadering
-      description: "Het bericht dat de JSON/REST API voor het ophalen van vergaderingsgegevens retourneert."
+      description: |
+                    Het bericht dat de JSON/REST API voor het ophalen van vergaderingsgegevens retourneert.
       parameters: 
         - in: path
           name: vergaderingsidentificatie
-          description: "De identificatie een VERGADERING De eerste vier karakter zijn de gemeentecode, gevolgd door een volgnummer van 7 cijfers met voorloopnullen."
+          description: |
+                        De identificatie een VERGADERING De eerste vier karakter zijn de gemeentecode, gevolgd door een volgnummer van 7 cijfers met voorloopnullen.
           required: true
           schema:
             type: string
@@ -725,7 +754,8 @@ paths:
           example: 1234567890
       responses:
         '200':
-          description: "Zoekactie geslaagd"
+          description: |
+                        Zoekactie geslaagd
           headers:
             api-version:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
@@ -763,11 +793,13 @@ paths:
       - Vergaderingen
     delete:
       operationId: DelVergadering
-      description: "Het bericht dat de JSON/REST API voor het verwijderen van een Vergadering."
+      description: |
+                    Het bericht dat de JSON/REST API voor het verwijderen van een Vergadering.
       parameters: 
         - in: path
           name: vergaderingsidentificatie
-          description: "De identificatie een VERGADERING De eerste vier karakter zijn de gemeentecode, gevolgd door een volgnummer van 7 cijfers met voorloopnullen."
+          description: |
+                        De identificatie een VERGADERING De eerste vier karakter zijn de gemeentecode, gevolgd door een volgnummer van 7 cijfers met voorloopnullen."
           required: true
           schema:
             type: string
@@ -807,8 +839,8 @@ components:
   schemas:
     Agendapunt:
       type: "object"
-      description: "Een onderdeel van de agenda dat als één geheel wordt behandeld.\
-        \ Een AGENDAPUNT kan weer onderverdeeld zijn naar subAGENDAPUNTen."
+      description: |
+                    Een onderdeel van de agenda dat als één geheel wordt behandeld. Een AGENDAPUNT kan weer onderverdeeld zijn naar subAGENDAPUNTen.
       required:
       - "agendapuntnummer"
       - "indicatieHamerstuk"
@@ -817,7 +849,8 @@ components:
       properties:
         "@context":
           type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
+          description: |
+                        T.b.v. het parsen vabn JSON-LD. Zie [documentatie](https://github.com/VNG-Realisatie/ODS-Open-Raadsinformatie/tree/master/docs/json_to_ld.md).
         "@id":
           type: string
           description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"

--- a/api-specificatie/refimplementatie/openapi.yaml
+++ b/api-specificatie/refimplementatie/openapi.yaml
@@ -571,7 +571,7 @@ paths:
           schema:
             type: integer
             minimum: 1
-        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/parameters.yaml#/expand"
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/parameters/expand"
         - in: query
           name: naam
           description: |
@@ -853,57 +853,57 @@ components:
                         T.b.v. het parsen vabn JSON-LD. Zie [documentatie](https://github.com/VNG-Realisatie/ODS-Open-Raadsinformatie/tree/master/docs/json_to_ld.md).
         "@id":
           type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
+          description: | 
+                          Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting
         "@type":
           type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
+          description: |
+                        Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting
         agendapuntKenmerk:
           type: "string"
           title: "Agendapunt kenmerk"
-          description: "De weergave van het Agendapuntvolgnummer op de agenda. Dit\
-            \ is de letterlijke volgorde van een Agendapunt wordt bij gehouden d.m.v.\
-            \ attribuut 'Agendapuntvolgnummer'. Hoe het Agendapunt getoond wordt op\
-            \ de Agenda wordt beschreven met attribuut 'Agendapunt kenmerk'."
+          description: |
+                        De weergave van het Agendapuntvolgnummer op de agenda. Dit is de letterlijke volgorde van een Agendapunt wordt bij gehouden d.m.v attribuut 'Agendapuntvolgnummer'. Hoe het Agendapunt getoond wordt op de Agenda wordt beschreven met attribuut 'Agendapunt kenmerk'.
           maxLength: 20
         agendapuntnummer:
           type: "string"
           title: "Agendapuntnummer"
-          description: "Het nummer van het agendapunt op de agenda."
+          description: |
+                        Het nummer van het agendapunt op de agenda.
           maxLength: 10
           minLength: 1
         agendapuntOmschrijving:
           type: "string"
           title: "Agendapunt omschrijving"
-          description: "De omschrijving van het agendapunt"
+          description: |
+                        De omschrijving van het agendapunt
         agendapuntvolgnummer:
           type: "string"
           title: "Agendapuntvolgnummer"
-          description: "Dit is het volgnummer van het AGENDAPUNT tijdens de vergadering.\
-            \ Dit is de letterlijke volgorde en zegt niets over hoe dit volgnummer\
-            \ getoond wordt. Hoe het Agendapunt getoond wordt op de Agenda wordt beschreven\
-            \ met attribuut 'Agendapunt kenmerk'."
+          description: |
+                        Dit is het volgnummer van het AGENDAPUNT tijdens de vergadering. Dit is de letterlijke volgorde en zegt niets over hoe dit volgnummer getoond wordt. Hoe het Agendapunt getoond wordt op de Agenda wordt beschreven met attribuut 'Agendapunt kenmerk'.
           maxLength: 3
         eindtijd:
           type: "string"
           title: "Eindtijd"
-          description: "De datum en tijdstip waarop de behandeling van de agendapunt\
-            \ is geëindigd Moet voor komen als Starttijd voorkomt"
+          description: | 
+                        De datum en tijdstip waarop de behandeling van de agendapunt is geëindigd Moet voor komen als Starttijd voorkomt
         geplandAgendapuntvolgnummer:
           type: "string"
           title: "Gepland agendapuntvolgnummer"
-          description: "Dit is het geplande volgnummer van het AGENDAPUNT van een\
-            \ vergadering."
+          description: |  
+                        Dit is het geplande volgnummer van het AGENDAPUNT van een vergadering.
           maxLength: 10
         geplandeEindtijd:
           type: "string"
           title: "Geplande eindtijd"
-          description: "De geplande datum en tijdstip waarop de behandeling van de\
-            \ agendapunt eindigt"
+          description: | 
+                        De geplande datum en tijdstip waarop de behandeling van de agendapunt eindigt
         geplandeStarttijd:
           type: "string"
           title: "Geplande starttijd"
-          description: "De geplande datum en tijdstip waarop de behandeling van de\
-            \ agendapunt start"
+          description: |
+                        De geplande datum en tijdstip waarop de behandeling van de agendapunt start
         indicatieHamerstuk:
           type: "boolean"
           title: "Indicatie hamerstuk"
@@ -912,81 +912,90 @@ components:
         indicatorBehandeld:
           type: "boolean"
           title: "Indicator behandeld"
-          description: "Indicator geeft aan of het AGENDAPUNT is behandeld tijdens\
-            \ de VERGADERING. Is eventueel af te leiden als Starttijd en/of Eindtijd\
-            \ zijn ingevuld defaultwaarde = nee"
+          description: |
+                        Indicator geeft aan of het AGENDAPUNT is behandeld tijdens de VERGADERING. Is eventueel af te leiden als Starttijd en/of Eindtijd zijn ingevuld defaultwaarde = nee
         indicatorBesloten:
           type: "boolean"
           title: "Indicator besloten"
-          description: "Indicator of een AGENDAPUNT besloten wordt behandeld defaultwaarde\
-            \ = nee"
+          description: |
+                        Indicator of een AGENDAPUNT besloten wordt behandeld defaultwaarde = nee
         starttijd:
           type: "string"
           title: "Starttijd"
-          description: "De datum en tijdstip waarop de behandeling van de agendapunt\
-            \ is gestart"
+          description: |
+                        De datum en tijdstip waarop de behandeling van de agendapunt is gestart
         _links:
           $ref: "#/components/schemas/Agendapunt_links"
     Vergadering:
       type: "object"
-      description: "Een VERGADERING is een bijeenkomst van meerdere mensen die met\
-        \ elkaar spreken en/of afspraken maken over onderwerpen die op de agenda staan."
+      description: | 
+                    Een VERGADERING is een bijeenkomst van meerdere mensen die met elkaar spreken en/of afspraken maken over onderwerpen die op de agenda staan.
       required:
       - "vergaderingsidentificatie"
       - "vergaderingstype"
       properties:
         "@context":
           type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
+          description: |
+                        Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting
         "@id":
           type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
+          description: |
+                        Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting
         "@type":
-          type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
+          type: "string"
+          description: |
+                        Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting
         aanvangVergadering:
           type: "string"
           title: "Aanvang vergadering"
-          description: "De datum en tijdstip waarop de vergadering is gestart Komt\
-            \ zeker voor als Einde vergadering ook is ingevuld"
+          description: |
+                        De datum en tijdstip waarop de vergadering is gestart Komt zeker voor als Einde vergadering ook is ingevuld
           example: "2017-02-10T18:25:00:000Z"
         audioLink:
           type: "string"
           title: "Audio link"
-          description: "De link naar de audio opname van de VERGADERING"
+          description: |
+                        De link naar de audio opname van de VERGADERING
           format: "uri"
           example: "https://www.voorbeeldgemeente.nl/audio/link"
         eindeVergadering:
           type: "string"
           title: "Einde vergadering"
-          description: "De datum en tijdstip waarop de vergadering is geëindigd"
+          description: |
+                        De datum en tijdstip waarop de vergadering is geëindigd
           example: "2017-02-10T21:12:00:000Z"
         geplandeAanvangVergadering:
           type: "string"
           title: "Geplande aanvang vergadering"
-          description: "De geplande datum en tijdstip waarop de vergadering start"
+          description: |
+                        De geplande datum en tijdstip waarop de vergadering start
           example: "2017-02-09T18:25:00:000Z"
         geplandeEindeVergadering:
           type: "string"
           title: "Geplande einde vergadering"
-          description: "De geplande datum en tijdstip waarop de vergadering eindigt"
+          description: |
+                        De geplande datum en tijdstip waarop de vergadering eindigt
           example: "2017-02-09T21:25:00:000Z"
         geplandeVergaderdatum:
           type: "string"
           title: "Geplande vergaderdatum"
-          description: "De geplande datum van de VERGADERING"
+          description: |
+                        De geplande datum van de VERGADERING
           format: "date"
           example: "2017-02-09"
         locatie:
           type: "string"
           title: "Locatie"
-          description: "Omschrijving van de locatie waar de vergadering wordt gehouden"
+          description: |
+                        Omschrijving van de locatie waar de vergadering wordt gehouden
           maxLength: 100
           example: "Raadszaal, Stadskantoor, Overtoom 2"
         naam:
           type: "string"
           title: "Naam"
-          description: "De naam van de vergadering"
+          description: |
+                        De naam van de vergadering
           maxLength: 100
           example: "Raadsvergadering"
         status:
@@ -994,14 +1003,15 @@ components:
         vergaderdatum:
           type: "string"
           title: "Vergaderdatum"
-          description: "De datum van de VERGADERING"
+          description: |
+                        De datum van de VERGADERING
           format: "date"
           example: "2017-02-10"
         vergaderingsidentificatie:
           type: "string"
           title: "Vergaderingsidentificatie"
-          description: "De identificatie een VERGADERING De eerste vier karakter zijn\
-            \ de gemeentecode, gevolgd door een volgnummer van 7 cijfers met voorloopnullen."
+          description: |
+                        De identificatie een VERGADERING De eerste vier karakter zijn de gemeentecode, gevolgd door een volgnummer van 7 cijfers met voorloopnullen."
           maxLength: 10
           minLength: 1
           example: "1234567890"
@@ -1010,12 +1020,14 @@ components:
         vergaderToelichting:
           type: "string"
           title: "Vergader toelichting"
-          description: "De toelichting of nadere omschrijving van de vergadering"
+          description: |
+                        De toelichting of nadere omschrijving van de vergadering
           example: "Regulier geplande raadsvergadering van mei"
         videoLink:
           type: "string"
           title: "Video link"
-          description: "De link naar de video opname van de VERGADERING"
+          description: |
+                        De link naar de video opname van de VERGADERING
           format: "uri"
           example: "https://www.voorbeeldgemeente.nl/video/link"
         _links:
@@ -1023,8 +1035,7 @@ components:
     Informatieobject:
       type: "object"
       description: | 
-                    Deze resource correspondeert met het enkelvoudig informatieobject en al zijn specialisaties. 
-                    Voor de implementatie zijn alle objecttype die onder het informatieobject voorkomen samengevoegd in deze resource. 
+                    Deze resource correspondeert met het enkelvoudig informatieobject en al zijn specialisaties. Voor de implementatie zijn alle objecttype die onder het informatieobject voorkomen samengevoegd in deze resource. 
       required:
       - "auteur"
       - "bronorganisatie"
@@ -1035,208 +1046,102 @@ components:
       properties:
         "@context":
           type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
+          description: |
+                        Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting
         "@id":
           type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
+          description: |
+                        Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting
         "@type":
           type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
+          description: |
+                        Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting
         informatieobjectType: 
           $ref: "#/components/schemas/InformatieobjecttypeEnum"
         auteur:
           type: "string"
           title: "Auteur"
-          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk\
-            \ is voor het creëren van de inhoud van het INFORMATIEOBJECT. Het kan\
-            \ zowel een medewerker of organisatorische eenheid van de zaakbehandelende\
-            \ organisatie betreffen als een externe partij (persoon of organisatie).\
-            \ Het betreft het Dublin Core metadata-element ‘Creator’ met als toelichting:\
-            \ Examples of Creator include a person, an organization, or a service.\
-            \ Typically, the name of a Creator should be used to indicate the entity.\
-            \ Van een ontvangen informatieobject kan de afzender de auteur zijn maar\
-            \ dat kan ook een ander zijn bijvoorbeeld in het geval dat de afzender\
-            \ een document van een derde meestuurt. Indien het informatieobject in\
-            \ een geautomatiseerd proces is vervaardigd, dan wordt als auteur vermeld\
-            \ degene die dat informatieobject ondertekend zou hebben dan wel, bij\
-            \ informatieobjecten waarbij van ondertekening geen sprake is (zoals bijvoorbeeld\
-            \ bij het omzetten van de zaakgegevens naar een duurzaam bewaarbaar informatieobject\
-            \ in pdf), degene die verantwoordelijk is voor de inhoud van het informatieobject\
-            \ vanuit zijn of haar rol bij de zaak (veelal degene in de rol van Zaakcoö\
-            rdinator). De naamgegevens van de auteur zijnde een betrokkene die in\
-            \ een rol aan de ZAAK gerelateerd is, dan wel, indien de auteur niet in\
-            \ een rol aan de ZAAK gerelateerd is, de naamgegevens van de natuurlijk\
-            \ persoon of organisatie zijnde de auteur. In het laatste geval verdient\
-            \ het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap\
-            \ wordt uitgeoefend."
+          description: |
+                        De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creëren van de inhoud van het INFORMATIEOBJECT.
           maxLength: 200
           minLength: 1
         bronorganisatie:
           type: "integer"
           title: "Bronorganisatie"
-          description: "bronorganisatie bronorganisatie Het RSIN van de Niet-natuurlijk\
-            \ persoon zijnde de organisatie die het informatieobject heeft gecreë\
-            erd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd.\
-            \ Het betreft het RSIN (Rechtspersonen en Samenwerkingsverbanden InformatieNummer)\
-            \ zoals dat door de KvK in het NHR aan elk rechtspersoon en samenwerkingsverband\
-            \ is toegekend. Dit identificeert uniek de organisatie, zijnde een rechtspersoon\
-            \ of samenwerkingsverband, dat het informatieobject heeft gecreëerd of\
-            \ heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd.\
-            \ Met het laatste doelen we er op dat bij uitwisseling van een informatieobject\
-            \ tussen samenwerkende organisaties de unieke aanduiding van het informatieobject\
-            \ niet wijzigt mits de ontvangende organisatie geen wijzigingen in het\
-            \ informatieobject aanbrengt. In het laatste geval ontstaat een nieuw\
-            \ informatieobject. Het RSIN staat in het Handelsregister (NHR) en op\
-            \ het daaraan te ontlenen uittreksel. Deze attribuutsoort vormt tezamen\
-            \ met de Informatieobjectidentificatie de unieke aanduiding van een informatieobject\
-            \ voor geheel Nederland. De waarde van dit attribuutsoort wijzigt niet,\
-            \ ook niet indien (de behandeling van) het informatieobject over zou gaan\
-            \ naar een andere organisatie. Er is immers maar één organisatie die het\
-            \ informatieobject gecreëerd of als eerste vastgelegd heeft. De in het\
-            \ NHR voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden."
-          maximum: 9.99999999E8
+          description: |
+                        Het RSIN van de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd.
         creatiedatum:
           type: "string"
           title: "Creatiedatum"
-          description: "creatiedatum creatiedatum Een datum of een gebeurtenis in\
-            \ de levenscyclus van het INFORMATIEOBJECT. Deze datum verwijst gewoonlijk\
-            \ naar de creatie van het INFORMATIEOBJECT. Het betreft het Dublin Core\
-            \ metadata-element ‘Date’ met als toelichting: Typically, Date will be\
-            \ associated with the creation or availability of the resource. Recommended\
-            \ best practice for encoding the date value is defined in a profile of\
-            \ ISO 8601 (W3CDTF) and includes (among others) dates of the form YYYY-MM-DD.\
-            \ Alle geldige datums gelegen op of voor de huidige datum en tijd"
+          description: |
+                        Deze datum verwijst gewoonlijk naar de creatie van het INFORMATIEOBJECT.
           format: "date"
         informatieobjectidentificatie:
           type: "string"
           title: "Informatieobjectidentificatie"
-          description: "informatieobjectidentificatie informatieobjectidentificatie\
-            \ Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT.\
-            \ Het gaat om een uniek kenmerk, gevormd door een reeks letters, cijfers\
-            \ en/of leestekens, dat het informatieobject uniek identificeert binnen\
-            \ de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen\
-            \ en als eerste in een samenwerkingsketen heeft vastgelegd (cq. de ‘gegeven\
-            \ context’). Door combinatie met het RSIN van die organisatie, als waarde\
-            \ van de attribuutsoort ‘Bronorganisatie’, wordt een voor geheel Nederland\
-            \ unieke aanduiding van informatieobjecten verkregen. Het betreft het\
-            \ Dublin Core metadata-element ‘Identifier’ met als toelichting: Recommended\
-            \ best practice is to identify the resource by means of a string or number\
-            \ conforming to a formal identification system. Formal identification\
-            \ systems include but are not limited to the Uniform Resource Identifier\
-            \ (URI) (including the Uniform Resource Locator (URL)), the Digital Object\
-            \ Identifier (DOI), and the International Standard Book Number (ISBN).\
-            \ Alle alfanumerieke tekens m.u.v. diacrieten"
+          description: |
+                        Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT.
           maxLength: 40
           minLength: 1
         ontvangstdatum:
           type: "string"
           title: "Ontvangstdatum"
-          description: "ontvangstdatum ontvangstdatum De datum waarop het INFORMATIEOBJECT\
-            \ ontvangen is. Het gaat hier om de datum waarop het INFORMATIEOBJECT\
-            \ ontvangen is door de zaakbehandelende organisatie(s), dus niet door\
-            \ een specifieke afdeling of medewerker daarvan. Alle geldige datums gelegen\
-            \ op, voor of na de huidige datum en tijd"
+          description: |
+                        De datum waarop het INFORMATIEOBJECT ontvangen is. 
           format: "date"
         titel:
           type: "string"
           title: "Titel"
-          description: "titel titel De naam waaronder het INFORMATIEOBJECT formeel\
-            \ bekend is. Het betreft het Dublin Core metadata-element ‘Title’ met\
-            \ als toelichting: Typically, Title will be a name by which the resource\
-            \ is formally known. alle alfanumerieke tekens"
+          description: |
+                        De naam waaronder het INFORMATIEOBJECT formeel bekend is.
           maxLength: 200
           minLength: 1
         versie:
           type: "string"
           title: "Versie"
-          description: "versie versie Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT\
-            \ Het gaat hier om een versienummer zoals ‘0.2’ en 1.0’. Ofschoon we er\
-            \ voor gekozen hebben om zowel dit attribuuttype als het attribuuttype\
-            \ Status optioneel te verklaren, ware het aan te bevelen bij elk documemt\
-            \ in ieder geval één van beide attributen van een waarde te voorzien.\
-            \ Nb: De attribuutsoort is in versie 2.0 verplaatst van ENKELVOUDIG INFORMATIEOBJECT\
-            \ naar INFORMATIEOBJECT. Alle alfanumerieke tekens m.u.v. diacrieten"
+          description: |
+                        Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT. Het gaat hier om een versienummer zoals ‘0.2’ en 1.0’. 
           maxLength: 5
         bestandsomvang:
           type: "integer"
           title: "Bestandsomvang"
-          description: "Ruimtebeslag op het digitale opslagmedium waarin het fysieke\
-            \ bestand met de inhoud van het INFORMATIEOBJECT is vastgelegd Ofschoon\
-            \ dit een afleidbaar gegeven is, aangezien het af te leiden is uit het\
-            \ fysieke bestand, is er voor gekozen dit gegeven toch op te nemen.\
-            \ Het kunnen afleiden van dit gegeven veronderstelt dat het bestand\
-            \ zelf beschikbaar is om dit gegeven af te kunnen leiden en dat functionaliteiten\
-            \ hiervoor beschikbaar zijn. Hiervan is niet altijd sprake. Omvang van\
-            \ het fysieke bestand in aantal bytes."
-          maximum: 9.999999999E9
+          description: |
+                        Ruimtebeslag op het digitale opslagmedium waarin het fysieke bestand met de inhoud van het INFORMATIEOBJECT is vastgelegd 
         formaat:
           type: "string"
           title: "Formaat"
-          description: "De code voor de wijze waarop de inhoud van het ENKELVOUDIG\
-            \ INFORMATIEOBJECT is vastgelegd in een computerbestand. Het gaat hier\
-            \ om de bestandsoort van het enkelvoudig informatieobject. Het betreft\
-            \ het Dublin Core metadata-element ‘Format’ met als toelichting: Typically,\
-            \ Format will include the media-type or dimensions of the resource.\
-            \ Format may be used to identify the software, hardware, or other equipment\
-            \ needed to display or operate the resource. Examples of dimensions\
-            \ include size and duration. Recommended best practice is to select\
-            \ a value from a controlled vocabulary (for example, the list of Internet\
-            \ Media Types (MIME) defining computer media formats). Aangezien, bij\
-            \ bijvoorbeeld omzetting naar een duurzaam bewaarbaar informatieobject,\
-            \ het formaat kan wijzigen kent deze attribuutsoort historie. MIME-types\
-            \ en –subtypes conform IANA"
+          description: |
+                        De code voor de wijze waarop de inhoud van het ENKELVOUDIG INFORMATIEOBJECT is vastgelegd in een computerbestand. Het gaat hier om de bestandsoort van het enkelvoudig informatieobject. 
           minLength: 1
         inhoud:
           type: "string"
           title: "Inhoud"
-          description: "Datgene wat in een ENKELVOUDIG INFORMATIEOBJECT wordt meegedeeld.\
-            \ Het gaat hier om de inhoud of content van het ENKELVOUDIG INFORMATIEOBJECT\
-            \ (in het spraakgebruik ‘de tekst van het document’) in het formaat\
-            \ zoals vastgelegd in Formaat. Veelal gaat het om de tekst van een ENKELVOUDIG\
-            \ INFORMATIEOBJECT (bijvoorbeeld in pdf-formaat). Het kan bijvoorbeeld\
-            \ ook een afbeelding (in bijvoorbeeld jpg-formaat) of een kaart (in\
-            \ bijvoorbeeld gmlformaat) betreffen. De mogelijkheid bestaat dat de\
-            \ inhoud in een (al dan niet separaat) bestand wordt uitgewisseld of\
-            \ dat er alleen verwezen wordt naar de locatie waar zich de inhoud bevindt.\
-            \ Hiertoe zijn de attribuutsoorten Bestandsnaam respectievelijk Link\
-            \ opgenomen. De content (data) van het enkelvoudig informatieobject\
-            \ in het formaat zoals gespecificeerd met de attribuutsoort 'Formaat'."
+          description: |
+                        Datgene wat in een ENKELVOUDIG INFORMATIEOBJECT wordt meegedeeld.
         link:
           type: "string"
           title: "Link"
-          description: "De URL waarmee de inhoud van het INFORMATIEOBJECT op te\
-            \ vragen is. Vanwege vooral technische belemmeringen kan het voorkomen\
-            \ dat de attribuutsoort Inhoud geen waarde heeft d.w.z. dat de inhoud\
-            \ van het informatieobject ('het document' in het spraakgebruik) niet\
-            \ uitgewisseld wordt. Het attribuutsoort Link verwijst dan naar de locatie\
-            \ waar de inhoud van het informatieobject ('het document') zich bevindt\
-            \ en schept de mogelijkheid de Inhoud ('het document') op te vragen.\
-            \ Een meer structurelere wijze om de Inhoud op te vragen, is uiteraard\
-            \ met behulp van de Identificatie."
+          description: |
+                        De URL waarmee de inhoud van het INFORMATIEOBJECT op te vragen is. 
           format: "uri"
         taal:
           type: "string"
           title: "Taal"
-          description: "Een taal van de intellectuele inhoud van het ENKELVOUDIG\
-            \ INFORMATIEOBJECT Het betreft het Dublin Core metadata-element ‘Language’\
-            \ met als toelichting: Recommended best practice is to use RFC 3066\
-            \ (RFC3066), which, in conjunction with ISO 639 (ISO639), defines two-\
-            \ and three-letter primary language tags with optional subtags. Examples\
-            \ include “en” or “eng” for English, “akk` for Akkadian, and “en-GB”\
-            \ for English used in the United Kingdom. De Nederlandse taal wordt\
-            \ gecodeerd als “dut”. bij voorkeur ISO 639-2/B"
+          description: |
+                        Een taal van de intellectuele inhoud van het INFORMATIEOBJECT
           maxLength: 20
           minLength: 1
         datumIngediend:
           type: "string"
           title: "Datum ingediend"
-          description: "De datum waarop het BESLUITVORMINGSSTUK is ingediend"
+          description: |
+                        De datum waarop het BESLUITVORMINGSSTUK is ingediend
           format: "date"
         omschrijving:
           type: "string"
           title: "Omschrijving"
-          description: "De omschrijving van het BESLUITVORMINGSSTUK Dit kan de omschrijving\
-            \ zijn van de MOTIE, het AMENDEMENT of het VOORSTEL"
+          description: |
+                        De omschrijving van het BESLUITVORMINGSSTUK Dit kan de omschrijving zijn van de MOTIE, het AMENDEMENT of het VOORSTEL
         typeVraag:
           $ref: "#/components/schemas/VraagType"
         typeMotie:
@@ -1248,7 +1153,8 @@ components:
       properties:
         "@id":
           type: string
-          description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
+          description: |
+                        Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting
         "@context":
             type: string
             format: "uri"

--- a/api-specificatie/refimplementatie/openapi.yaml
+++ b/api-specificatie/refimplementatie/openapi.yaml
@@ -18,12 +18,12 @@ paths:
     get:
       operationId: GetAgendapunt
       summary: Raadpleeg agendapunt op unieke identificatie.
-      description: | 
+      description: |
                     Het bericht dat de JSON/REST API voor het ophalen van gegevens van een agendapunt retourneert."
-      parameters: 
+      parameters:
         - in: path
           name: agendapuntnummer
-          description: | 
+          description: |
                         Unieke identificatie van het agendapunt.
           required: true
           schema:
@@ -31,7 +31,7 @@ paths:
             maxLength: 10
       responses:
         '200':
-          description: | 
+          description: |
                         Zoekactie geslaagd
           headers:
             api-version:
@@ -62,17 +62,17 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
         'default':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
-      tags: 
+      tags:
       - Agendapunten
     delete:
       operationId: DelAgendapunt
       summary: Verwijder agendapunt
       description: |
                     Het bericht dat de JSON/REST API voor het verwijderen van agendapunt.
-      parameters: 
+      parameters:
         - in: path
           name: agendapuntnummer
-          description: | 
+          description: |
                         Unieke identificatie van het agendapunt.
           required: true
           schema:
@@ -102,7 +102,7 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
         'default':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
-      tags: 
+      tags:
         - Agendapunten
   /agendapunten:
     get:
@@ -110,7 +110,7 @@ paths:
       summary: Zoek agendapunten
       description: |
                     Het bericht dat de JSON/REST API voor het ophalen van een collectie agendapunten retourneert.
-      parameters: 
+      parameters:
         - in: query
           name: pagina
           description: |
@@ -174,7 +174,7 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
         'default':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
-      tags: 
+      tags:
       - Agendapunten
     post:
       operationId: PostAgendapunt
@@ -184,7 +184,7 @@ paths:
       responses:
         '201':
           description: ""
-          headers: 
+          headers:
             api-version:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
           content:
@@ -262,11 +262,11 @@ paths:
       summary: Raadpleeg informatieobject
       description: |
                     Het bericht dat de JSON/REST API voor het ophalen van gegevens van een informatieobject retourneert.
-      parameters: 
+      parameters:
         - in: path
           name: informatieobjectidentificatie
           description: |
-                        Unieke identificatie van een informatieobject. 
+                        Unieke identificatie van een informatieobject.
           required: true
           schema:
             type: string
@@ -308,18 +308,18 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
         'default':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
-      tags: 
+      tags:
       - Informatieobjecten
     delete:
       operationId: DelInformatieobject
       summary: Verwijder informatieobject
       description: |
                     Het bericht dat de JSON/REST API voor het verwijderen van informatieobject.
-      parameters: 
+      parameters:
         - in: path
           name: informatieobjectidentificatie
           description: |
-                        Unieke identificatie van het informatieobject. 
+                        Unieke identificatie van het informatieobject.
           required: true
           schema:
             type: string
@@ -352,7 +352,7 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
         'default':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
-      tags: 
+      tags:
         - Informatieobjecten
   /informatieobjecten:
     get:
@@ -360,7 +360,7 @@ paths:
       summary: Zoek informatieobjecten
       description: |
                     Het bericht dat de JSON/REST API voor het ophalen van een collectie informatieobjecten retourneert.
-      parameters: 
+      parameters:
         - in: query
           name: pagina
           description: "Een pagina binnen de gepagineerde resultatenset."
@@ -370,7 +370,7 @@ paths:
             minimum: 1
         - in: query
           name: auteur
-          description: | 
+          description: |
                         De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creëren van de inhoud van het INFORMATIEOBJECT.
           required: false
           schema:
@@ -379,7 +379,7 @@ paths:
         - in: query
           name: bronorganisatie
           description: |
-                        Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. 
+                        Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd.
           required: false
           schema:
             type: integer
@@ -410,7 +410,7 @@ paths:
         - in: query
           name: ontvangstdatum
           description: |
-                        De datum waarop het INFORMATIEOBJECT ontvangen is. 
+                        De datum waarop het INFORMATIEOBJECT ontvangen is.
           required: false
           schema:
             type: string
@@ -426,7 +426,7 @@ paths:
         - in: query
           name: titel
           description: |
-                        De naam waaronder het INFORMATIEOBJECT formeel bekend is. 
+                        De naam waaronder het INFORMATIEOBJECT formeel bekend is.
           required: false
           schema:
             type: string
@@ -470,7 +470,7 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
         'default':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
-      tags: 
+      tags:
       - Informatieobjecten
     post:
       operationId: PostInformatieobject
@@ -516,7 +516,7 @@ paths:
     put:
       operationId: PutInformatieobject
       summary: Wijzig informatieobject
-      description: |    
+      description: |
                     Wijzig een bestaand Informnatieobject"
       responses:
         '200':
@@ -562,7 +562,7 @@ paths:
       operationId: GetVergaderingen
       description: |
                     Het bericht dat de JSON/REST API voor het ophalen van vergaderingsgegevens retourneert.
-      parameters: 
+      parameters:
         - in: query
           name: pagina
           description: |
@@ -653,7 +653,7 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
         'default':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
-      tags: 
+      tags:
       - Vergaderingen
     post:
       operationId: postVergadering
@@ -710,7 +710,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/Vergadering' 
+                $ref: '#/components/schemas/Vergadering'
         '400':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
         '401':
@@ -742,7 +742,7 @@ paths:
       operationId: GetVergadering
       description: |
                     Het bericht dat de JSON/REST API voor het ophalen van vergaderingsgegevens retourneert.
-      parameters: 
+      parameters:
         - in: path
           name: vergaderingsidentificatie
           description: |
@@ -789,13 +789,13 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
         'default':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
-      tags: 
+      tags:
       - Vergaderingen
     delete:
       operationId: DelVergadering
       description: |
                     Het bericht dat de JSON/REST API voor het verwijderen van een Vergadering.
-      parameters: 
+      parameters:
         - in: path
           name: vergaderingsidentificatie
           description: |
@@ -833,7 +833,7 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
         'default':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
-      tags: 
+      tags:
         - Vergaderingen
 components:
   schemas:
@@ -853,7 +853,7 @@ components:
                         T.b.v. het parsen vabn JSON-LD. Zie [documentatie](https://github.com/VNG-Realisatie/ODS-Open-Raadsinformatie/tree/master/docs/json_to_ld.md).
         "@id":
           type: string
-          description: | 
+          description: |
                           Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting
         "@type":
           type: string
@@ -886,18 +886,18 @@ components:
         eindtijd:
           type: "string"
           title: "Eindtijd"
-          description: | 
+          description: |
                         De datum en tijdstip waarop de behandeling van de agendapunt is geëindigd Moet voor komen als Starttijd voorkomt
         geplandAgendapuntvolgnummer:
           type: "string"
           title: "Gepland agendapuntvolgnummer"
-          description: |  
+          description: |
                         Dit is het geplande volgnummer van het AGENDAPUNT van een vergadering.
           maxLength: 10
         geplandeEindtijd:
           type: "string"
           title: "Geplande eindtijd"
-          description: | 
+          description: |
                         De geplande datum en tijdstip waarop de behandeling van de agendapunt eindigt
         geplandeStarttijd:
           type: "string"
@@ -924,11 +924,13 @@ components:
           title: "Starttijd"
           description: |
                         De datum en tijdstip waarop de behandeling van de agendapunt is gestart
+        gemeente:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
         _links:
           $ref: "#/components/schemas/Agendapunt_links"
     Vergadering:
       type: "object"
-      description: | 
+      description: |
                     Een VERGADERING is een bijeenkomst van meerdere mensen die met elkaar spreken en/of afspraken maken over onderwerpen die op de agenda staan.
       required:
       - "vergaderingsidentificatie"
@@ -1030,12 +1032,14 @@ components:
                         De link naar de video opname van de VERGADERING
           format: "uri"
           example: "https://www.voorbeeldgemeente.nl/video/link"
+        gemeente:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
         _links:
           $ref: "#/components/schemas/Vergadering_links"
     Informatieobject:
       type: "object"
-      description: | 
-                    Deze resource correspondeert met het enkelvoudig informatieobject en al zijn specialisaties. Voor de implementatie zijn alle objecttype die onder het informatieobject voorkomen samengevoegd in deze resource. 
+      description: |
+                    Deze resource correspondeert met het enkelvoudig informatieobject en al zijn specialisaties. Voor de implementatie zijn alle objecttype die onder het informatieobject voorkomen samengevoegd in deze resource.
       required:
       - "auteur"
       - "bronorganisatie"
@@ -1056,7 +1060,7 @@ components:
           type: string
           description: |
                         Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting
-        informatieobjectType: 
+        informatieobjectType:
           $ref: "#/components/schemas/InformatieobjecttypeEnum"
         auteur:
           type: "string"
@@ -1087,7 +1091,7 @@ components:
           type: "string"
           title: "Ontvangstdatum"
           description: |
-                        De datum waarop het INFORMATIEOBJECT ontvangen is. 
+                        De datum waarop het INFORMATIEOBJECT ontvangen is.
           format: "date"
         titel:
           type: "string"
@@ -1100,18 +1104,18 @@ components:
           type: "string"
           title: "Versie"
           description: |
-                        Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT. Het gaat hier om een versienummer zoals ‘0.2’ en 1.0’. 
+                        Aanduiding van de bewerkingsfase van het INFORMATIEOBJECT. Het gaat hier om een versienummer zoals ‘0.2’ en 1.0’.
           maxLength: 5
         bestandsomvang:
           type: "integer"
           title: "Bestandsomvang"
           description: |
-                        Ruimtebeslag op het digitale opslagmedium waarin het fysieke bestand met de inhoud van het INFORMATIEOBJECT is vastgelegd 
+                        Ruimtebeslag op het digitale opslagmedium waarin het fysieke bestand met de inhoud van het INFORMATIEOBJECT is vastgelegd
         formaat:
           type: "string"
           title: "Formaat"
           description: |
-                        De code voor de wijze waarop de inhoud van het ENKELVOUDIG INFORMATIEOBJECT is vastgelegd in een computerbestand. Het gaat hier om de bestandsoort van het enkelvoudig informatieobject. 
+                        De code voor de wijze waarop de inhoud van het ENKELVOUDIG INFORMATIEOBJECT is vastgelegd in een computerbestand. Het gaat hier om de bestandsoort van het enkelvoudig informatieobject.
           minLength: 1
         inhoud:
           type: "string"
@@ -1122,7 +1126,7 @@ components:
           type: "string"
           title: "Link"
           description: |
-                        De URL waarmee de inhoud van het INFORMATIEOBJECT op te vragen is. 
+                        De URL waarmee de inhoud van het INFORMATIEOBJECT op te vragen is.
           format: "uri"
         taal:
           type: "string"
@@ -1146,6 +1150,12 @@ components:
           $ref: "#/components/schemas/VraagType"
         typeMotie:
           $ref: "#/components/schemas/MotieType"
+        gemeente:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/apAi-specificatie/common.yaml#/components/schemas/Waardetabel"
+        vergaderingIdentificaties:
+          type: "array"
+          items:
+            type: "string"
         _links:
           $ref: "#/components/schemas/InformatieobjectLinks"
     Agendapunt_links:
@@ -1159,7 +1169,7 @@ components:
             type: string
             format: "uri"
             example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
+            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
         self:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         informatieobjecten:
@@ -1193,13 +1203,13 @@ components:
             type: string
             format: "uri"
             example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
+            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
         self:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         hoortBijInformatieobject:
           title: "heeftBetrekkingOp"
           type: "object"
-          description: | 
+          description: |
                         Een informatieobject heeft een relatie met een ander informatieobject. Bijvoorbeeld Een subamendement is een wijzigingsvoorstel voor een amendement en een antwoord hoort bij een vraag en een amendement heeft betrekking op een voorstel.
           properties:
             href:
@@ -1214,7 +1224,7 @@ components:
             type: string
             format: "uri"
             example: "href: @id "
-            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"        
+            description: "Additioneel element om het mogelijk te maken om JSON-LD te parsen. Zie [documentatie](https://github.com/VNG-Realisatie/Open-Raadsinformatie/tree/master/docs/json_to_ld.md) voor nadere toelichting"
         self:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         aanwezigeDeelnemers:


### PR DESCRIPTION
Als eerste stap in de implementatie is in overleg met leveranciers en Koop bespolten om in eerste instantie de gegevens rondom  vergaderingen, agendapunten en informatieobjecten te ontsluiten via de standaard.  Deze onderdelen zijn in een referentieimplementatie beproefd. De specificaties daarvoor zijn vooralsnog opgenomen in /specificatie/refimplementatie.